### PR TITLE
[박선미] stpe-2 GET으로 회원가입

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ dependencies {
     implementation 'com.github.jknack:handlebars:4.2.0'
 
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.8.1'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
     testImplementation 'org.assertj:assertj-core:3.16.1'
 

--- a/src/main/java/constant/Uri.java
+++ b/src/main/java/constant/Uri.java
@@ -4,5 +4,6 @@ public class Uri {
     public static final String BASIC_INDEX_URI = "/index.html";
     public static final String USER_FORM_URI = "/user/form.html";
 
+    public static final String USER_CREATE_URI = "/user/create";
 
 }

--- a/src/main/java/controller/RestController.java
+++ b/src/main/java/controller/RestController.java
@@ -1,38 +1,55 @@
 package controller;
 
+import dto.UserFormRequestDto;
 import model.HttpRequest;
 import model.HttpResponse;
 import model.enums.HttpStatusCode;
 import model.enums.Method;
 import service.FileService;
 import service.ResponseService;
+import service.UserService;
 
 import java.io.FileNotFoundException;
 
-import static constant.SourcePath.BASIC_INDEX_PATH;
-import static constant.SourcePath.USER_FORM_PATH;
-import static constant.Uri.BASIC_INDEX_URI;
-import static constant.Uri.USER_FORM_URI;
+import static constant.Uri.USER_CREATE_URI;
+import static util.StringUtils.NO_CONTENT;
 
 public class RestController {
     private final FileService fileService;
+    private final UserService userService;
     private final ResponseService responseService;
 
     public RestController() {
         fileService = new FileService();
+        userService = new UserService();
         responseService = new ResponseService();
     }
 
     public HttpResponse route(HttpRequest httpRequest) throws FileNotFoundException {
         HttpResponse response = responseService.createNotFoundResponse(httpRequest);
-        if(httpRequest.match(Method.GET) && httpRequest.endsWithHtml()){
-            response = sendStaticFileResponse(httpRequest);
+        if (httpRequest.match(Method.GET) && httpRequest.endsWithHtml()) {
+            response = sendNotRestfulResponse(httpRequest);
         }
-        // TODO
-        if (httpRequest.match(Method.GET, USER_FORM_URI)) {
-            response = getHttpResponse(httpRequest, USER_FORM_PATH);
+
+        if (httpRequest.match(Method.GET, USER_CREATE_URI)) {
+            response = addUserByForm(httpRequest);
         }
         return response;
+    }
+
+    private HttpResponse addUserByForm(HttpRequest request) {
+        try {
+            UserFormRequestDto userFormRequestDto = request.paramsToDto();
+            userService.createByForm(userFormRequestDto);
+            return responseService
+                    .createHttpResponse(request, HttpStatusCode.CREATED, NO_CONTENT);
+        } catch (Exception e) {
+            return responseService.createBadRequestResponse(request);
+        }
+    }
+
+    private HttpResponse sendNotRestfulResponse(HttpRequest request) {
+        return getHttpResponse(request, request.getUri());
     }
 
     private HttpResponse getHttpResponse(HttpRequest request, String path) {

--- a/src/main/java/controller/RestController.java
+++ b/src/main/java/controller/RestController.java
@@ -25,9 +25,8 @@ public class RestController {
 
     public HttpResponse route(HttpRequest httpRequest) throws FileNotFoundException {
         HttpResponse response = responseService.createNotFoundResponse(httpRequest);
-        if (httpRequest.match(Method.GET, BASIC_INDEX_URI)) {
-            // TODO *.html static 한 것들은 그냥 넘겨주게
-            response = getHttpResponse(httpRequest, BASIC_INDEX_PATH);
+        if(httpRequest.match(Method.GET) && httpRequest.endsWithHtml()){
+            response = sendStaticFileResponse(httpRequest);
         }
         // TODO
         if (httpRequest.match(Method.GET, USER_FORM_URI)) {

--- a/src/main/java/controller/RestController.java
+++ b/src/main/java/controller/RestController.java
@@ -6,7 +6,7 @@ import model.HttpResponse;
 import model.enums.HttpStatusCode;
 import model.enums.Method;
 import service.FileService;
-import service.ResponseService;
+import mapper.ResponseMapper;
 import service.UserService;
 
 import java.io.FileNotFoundException;
@@ -17,16 +17,16 @@ import static util.StringUtils.NO_CONTENT;
 public class RestController {
     private final FileService fileService;
     private final UserService userService;
-    private final ResponseService responseService;
+    private final ResponseMapper responseMapper;
 
     public RestController() {
         fileService = new FileService();
         userService = new UserService();
-        responseService = new ResponseService();
+        responseMapper = new ResponseMapper();
     }
 
     public HttpResponse route(HttpRequest httpRequest) throws FileNotFoundException {
-        HttpResponse response = responseService.createNotFoundResponse(httpRequest);
+        HttpResponse response = responseMapper.createNotFoundResponse(httpRequest);
         if (httpRequest.match(Method.GET) && httpRequest.endsWithHtml()) {
             response = sendNotRestfulResponse(httpRequest);
         }
@@ -41,10 +41,10 @@ public class RestController {
         try {
             UserFormRequestDto userFormRequestDto = request.paramsToDto();
             userService.createByForm(userFormRequestDto);
-            return responseService
+            return responseMapper
                     .createHttpResponse(request, HttpStatusCode.CREATED, NO_CONTENT);
         } catch (Exception e) {
-            return responseService.createBadRequestResponse(request);
+            return responseMapper.createBadRequestResponse(request);
         }
     }
 
@@ -55,10 +55,10 @@ public class RestController {
     private HttpResponse getHttpResponse(HttpRequest request, String path) {
         try {
             String fileContents = fileService.openFile(path);
-            return responseService
+            return responseMapper
                     .createHttpResponse(request, HttpStatusCode.OK, fileContents);
         } catch (FileNotFoundException e) {
-            return responseService.createBadRequestResponse(request);
+            return responseMapper.createBadRequestResponse(request);
         }
     }
 }

--- a/src/main/java/dto/UserFormRequestDto.java
+++ b/src/main/java/dto/UserFormRequestDto.java
@@ -1,0 +1,50 @@
+package dto;
+
+import model.User;
+
+import java.util.Map;
+
+public class UserFormRequestDto {
+    private String userId;
+    private String password;
+    private String name;
+    private String email;
+
+    public UserFormRequestDto(String userId, String password, String name, String email) {
+        this.userId = userId;
+        this.password = password;
+        this.name = name;
+        this.email = email;
+    }
+
+    // 나중에 지워짐
+    public UserFormRequestDto(Map<String, Object> params) {
+        for (var entry : params.entrySet()) {
+            var key = entry.getKey();
+            var val = (String) entry.getValue();
+            switch (key) {
+                case "userId":
+                    this.userId = val;
+                    break;
+                case "password":
+                    this.password = val;
+                    break;
+                case "name":
+                    this.name = val;
+                    break;
+                case "email":
+                    this.email = val;
+                    break;
+            }
+        }
+    }
+
+    public User toEntity() {
+        return new User(
+                this.userId,
+                this.password,
+                this.name,
+                this.email
+        );
+    }
+}

--- a/src/main/java/mapper/ResponseMapper.java
+++ b/src/main/java/mapper/ResponseMapper.java
@@ -1,10 +1,10 @@
-package service;
+package mapper;
 
 import model.HttpRequest;
 import model.HttpResponse;
 import model.enums.HttpStatusCode;
 
-public class ResponseService {
+public class ResponseMapper {
     private static final String PAGE_NOT_FOUND = "요청하신 페이지가 없습니다.";
     private static final String PAGE_BAD_REQUEST = "잘못된 요청입니다.";
 

--- a/src/main/java/model/HttpHeader.java
+++ b/src/main/java/model/HttpHeader.java
@@ -3,8 +3,7 @@ package model;
 import java.util.HashMap;
 import java.util.Map;
 
-import static util.StringUtils.mapToHeaderFormat;
-import static util.StringUtils.splitBy;
+import static util.StringUtils.*;
 
 public class HttpHeader {
     private static final int KEY_INDEX = 0;
@@ -22,14 +21,13 @@ public class HttpHeader {
     public static HttpHeader of(String[] texts) {
         HashMap<String, String> contents = new HashMap<>();
         for (var text : texts) {
-            String[] splited = splitBy(text, ":");
+            String[] splited = splitBy(text, COLON_MARK);
             String key = splited[KEY_INDEX];
             String value = splited[VALUE_INDEX];
             contents.put(key, value);
         }
         return new HttpHeader(contents);
     }
-
 
     public HttpHeader newInstance() {
         // ??

--- a/src/main/java/model/HttpRequest.java
+++ b/src/main/java/model/HttpRequest.java
@@ -1,8 +1,10 @@
 package model;
 
+import dto.UserFormRequestDto;
 import model.enums.Method;
 
 public class HttpRequest {
+    public static final String HTML_FILE_FORMAT = ".html";
     private final RequestUri requestUri;
     private final String protocol;
     private final Method method;
@@ -37,4 +39,12 @@ public class HttpRequest {
         return requestUri.uriEndsWith(HTML_FILE_FORMAT);
     }
 
+    public String getUri() {
+        return requestUri.getUri();
+    }
+
+    //지워질 예정
+    public UserFormRequestDto paramsToDto() {
+        return this.requestUri.paramsToDto();
+    }
 }

--- a/src/main/java/model/HttpRequest.java
+++ b/src/main/java/model/HttpRequest.java
@@ -21,6 +21,10 @@ public class HttpRequest {
         return this.method == method && this.requestUri.match(uri);
     }
 
+    public boolean match(Method method) {
+        return this.method == method;
+    }
+
     public HttpHeader getHeader() {
         return httpHeader.newInstance();
     }
@@ -28,4 +32,9 @@ public class HttpRequest {
     public String getProtocol() {
         return this.protocol;
     }
+
+    public boolean endsWithHtml() {
+        return requestUri.uriEndsWith(HTML_FILE_FORMAT);
+    }
+
 }

--- a/src/main/java/model/HttpResponse.java
+++ b/src/main/java/model/HttpResponse.java
@@ -29,7 +29,6 @@ public class HttpResponse {
         // TODO 수정하기
         header.put("Content-Type", "text/html;charset=utf-8");
         header.put("Content-Length", String.valueOf(lengthOfBody));
-        header.put("URLEncoding", "UTF-8");
         HttpHeader httpHeader = HttpHeader.of(header);
 
         return new HttpResponse(

--- a/src/main/java/model/RequestUri.java
+++ b/src/main/java/model/RequestUri.java
@@ -45,4 +45,9 @@ public class RequestUri {
     public boolean match(String uri) {
         return this.uri.equals(uri);
     }
+
+    public boolean uriEndsWith(String s) {
+        return uri.endsWith(s);
+    }
+
 }

--- a/src/main/java/model/RequestUri.java
+++ b/src/main/java/model/RequestUri.java
@@ -63,4 +63,13 @@ public class RequestUri {
     public UserFormRequestDto paramsToDto() {
         return new UserFormRequestDto(this.params);
     }
+
+    @Override
+    public String toString() {
+        String s = "path uri = " + uri + "\n";
+        for (var entry : params.entrySet()) {
+            s += "[key = " + entry.getKey() + " / value = " + entry.getValue()+"]\n";
+        }
+        return s;
+    }
 }

--- a/src/main/java/model/RequestUri.java
+++ b/src/main/java/model/RequestUri.java
@@ -8,8 +8,12 @@ import static util.StringUtils.*;
 public class RequestUri {
     private static final int KEY_INDEX = 0;
     private static final int VALUE_INDEX = 1;
-    private String uri;
-    private Map<String, Object> params;
+    private static final int URI_INDEX = 0;
+    private static final int PARAMETERS_INDEX = 1;
+    private static final int LENGTH_WHEN_HAS_NO_VALUE = 1;
+
+    private final String uri;
+    private final Map<String, Object> params;
 
     public RequestUri(String uri, Map<String, Object> params) {
         this.uri = uri;
@@ -17,12 +21,18 @@ public class RequestUri {
     }
 
     public static RequestUri of(String text) {
-        String[] splitByAmpersand = splitBy(text, AMPERSAND_MARK);
-        String uri = splitByAmpersand[0];
+        String[] splitByAmpersand = splitBy(text, QUESTION_MARK); // /uri?a=a&b=2&c=
+        String uri = splitByAmpersand[URI_INDEX];
+
+        String[] paramArray = splitBy(splitByAmpersand[PARAMETERS_INDEX], AMPERSAND_MARK);
 
         HashMap<String, Object> params = new HashMap<>();
-        for (int i = 1; i < splitByAmpersand.length; i++) {
-            String[] splitByEqualMark = splitBy(splitByAmpersand[i], EQUAL_MARK);
+        for (int i = 0; i < paramArray.length; i++) {
+            String[] splitByEqualMark = splitBy(paramArray[i], EQUAL_MARK);
+
+            if (splitByEqualMark.length == LENGTH_WHEN_HAS_NO_VALUE) {
+                continue;
+            }
             String key = splitByEqualMark[KEY_INDEX];
             String value = splitByEqualMark[VALUE_INDEX];
             params.put(key, value);

--- a/src/main/java/model/RequestUri.java
+++ b/src/main/java/model/RequestUri.java
@@ -1,5 +1,7 @@
 package model;
 
+import dto.UserFormRequestDto;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -25,7 +27,7 @@ public class RequestUri {
         String uri = splitByQuestionMark[URI_INDEX];
 
         HashMap<String, Object> params = new HashMap<>();
-        if(splitByQuestionMark.length == LENGTH_WHEN_HAS_NO_VALUE) return new RequestUri(uri, params);
+        if (splitByQuestionMark.length == LENGTH_WHEN_HAS_NO_VALUE) return new RequestUri(uri, params);
 
         String[] paramArray = splitBy(splitByQuestionMark[PARAMETERS_INDEX], AMPERSAND_MARK);
         for (int i = 0; i < paramArray.length; i++) {
@@ -50,4 +52,12 @@ public class RequestUri {
         return uri.endsWith(s);
     }
 
+    public String getUri() {
+        return this.uri;
+    }
+
+    // 지워질 예정
+    public UserFormRequestDto paramsToDto() {
+        return new UserFormRequestDto(this.params);
+    }
 }

--- a/src/main/java/model/RequestUri.java
+++ b/src/main/java/model/RequestUri.java
@@ -21,12 +21,13 @@ public class RequestUri {
     }
 
     public static RequestUri of(String text) {
-        String[] splitByAmpersand = splitBy(text, QUESTION_MARK); // /uri?a=a&b=2&c=
-        String uri = splitByAmpersand[URI_INDEX];
-
-        String[] paramArray = splitBy(splitByAmpersand[PARAMETERS_INDEX], AMPERSAND_MARK);
+        String[] splitByQuestionMark = splitBy(text, QUESTION_MARK); // /uri?a=a&b=2&c=
+        String uri = splitByQuestionMark[URI_INDEX];
 
         HashMap<String, Object> params = new HashMap<>();
+        if(splitByQuestionMark.length == LENGTH_WHEN_HAS_NO_VALUE) return new RequestUri(uri, params);
+
+        String[] paramArray = splitBy(splitByQuestionMark[PARAMETERS_INDEX], AMPERSAND_MARK);
         for (int i = 0; i < paramArray.length; i++) {
             String[] splitByEqualMark = splitBy(paramArray[i], EQUAL_MARK);
 

--- a/src/main/java/model/RequestUri.java
+++ b/src/main/java/model/RequestUri.java
@@ -27,21 +27,24 @@ public class RequestUri {
         String uri = splitByQuestionMark[URI_INDEX];
 
         HashMap<String, Object> params = new HashMap<>();
-        if (splitByQuestionMark.length == LENGTH_WHEN_HAS_NO_VALUE) return new RequestUri(uri, params);
+        if (isArrayLengthOne(splitByQuestionMark)) return new RequestUri(uri, params);
 
         String[] paramArray = splitBy(splitByQuestionMark[PARAMETERS_INDEX], AMPERSAND_MARK);
         for (int i = 0; i < paramArray.length; i++) {
-            String[] splitByEqualMark = splitBy(paramArray[i], EQUAL_MARK);
+            String[] paramMap = splitBy(paramArray[i], EQUAL_MARK);
 
-            if (splitByEqualMark.length == LENGTH_WHEN_HAS_NO_VALUE) {
-                continue;
-            }
-            String key = splitByEqualMark[KEY_INDEX];
-            String value = splitByEqualMark[VALUE_INDEX];
+            if (isArrayLengthOne(paramMap)) continue;
+
+            String key = paramMap[KEY_INDEX];
+            String value = paramMap[VALUE_INDEX];
             params.put(key, value);
         }
 
         return new RequestUri(uri, params);
+    }
+
+    private static boolean isArrayLengthOne(String[] array) {
+        return array.length == LENGTH_WHEN_HAS_NO_VALUE;
     }
 
     public boolean match(String uri) {

--- a/src/main/java/model/enums/HttpStatusCode.java
+++ b/src/main/java/model/enums/HttpStatusCode.java
@@ -93,11 +93,4 @@ public enum HttpStatusCode {
     public String toString() {
         return value + " " + description;
     }
-
-    public static HttpStatusCode getByValue(int value) {
-        for(HttpStatusCode status : values()) {
-            if(status.value == value) return status;
-        }
-        throw new IllegalArgumentException("Invalid status code: " + value);
-    }
 }

--- a/src/main/java/service/UserService.java
+++ b/src/main/java/service/UserService.java
@@ -1,0 +1,12 @@
+package service;
+
+import db.Database;
+import dto.UserFormRequestDto;
+import model.User;
+
+public class UserService {
+    public void createByForm(UserFormRequestDto dto){
+        User userEntity = dto.toEntity();
+        Database.addUser(userEntity);
+    }
+}

--- a/src/main/java/util/StringUtils.java
+++ b/src/main/java/util/StringUtils.java
@@ -4,6 +4,8 @@ import java.util.Map;
 
 public class StringUtils {
     public static final String NEXTLINE = "\r\n";
+    public static final String NO_CONTENT = "";
+
     public static final String SPACE = " ";
 
     public static final String QUESTION_MARK = "\\?"; // 정규표현식 예약어

--- a/src/main/java/util/StringUtils.java
+++ b/src/main/java/util/StringUtils.java
@@ -6,7 +6,7 @@ public class StringUtils {
     public static final String NEXTLINE = "\r\n";
     public static final String SPACE = " ";
 
-    public static final String QUESTION_MARK = "?";
+    public static final String QUESTION_MARK = "\\?"; // 정규표현식 예약어
     public static final String AMPERSAND_MARK = "&";
     public static final String EQUAL_MARK = "=";
     public static final String COLON_MARK = ":";

--- a/src/main/java/util/StringUtils.java
+++ b/src/main/java/util/StringUtils.java
@@ -6,6 +6,7 @@ public class StringUtils {
     public static final String NEXTLINE = "\r\n";
     public static final String SPACE = " ";
 
+    public static final String QUESTION_MARK = "?";
     public static final String AMPERSAND_MARK = "&";
     public static final String EQUAL_MARK = "=";
     public static final String COLON_MARK = ":";

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -1,10 +1,10 @@
 package webserver;
 
+import controller.RestController;
 import model.HttpRequest;
 import model.HttpResponse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import controller.RestController;
 import util.Parser;
 
 import java.io.*;

--- a/src/main/java/webserver/WebServer.java
+++ b/src/main/java/webserver/WebServer.java
@@ -26,7 +26,7 @@ public class WebServer {
 
             // 클라이언트가 연결될때까지 대기한다.
             Socket connection;
-            ExecutorService executor = Executors.newFixedThreadPool(5);
+            ExecutorService executor = Executors.newWorkStealingPool();
             while ((connection = listenSocket.accept()) != null) {
                 executor.submit(new RequestHandler(connection));
             }

--- a/src/test/java/model/RequestUriTest.java
+++ b/src/test/java/model/RequestUriTest.java
@@ -1,0 +1,26 @@
+package model;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class RequestUriTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+            "/asdf",
+            "/a/b/c?ab=123&parameter=asdf&name=&age=123",
+            "/hi/hello?",
+            "/?abc=abc&name=kim&age",
+            "/name?name=name&kim=&abc&good=1234"
+    })
+    @DisplayName("path uri의 parameter를 잘 분해한다.")
+    void parsingPathUri(String path) {
+       RequestUri requestUri = RequestUri.of(path);
+
+        System.out.println(requestUri);
+    }
+}

--- a/src/test/java/service/FileServiceTest.java
+++ b/src/test/java/service/FileServiceTest.java
@@ -1,0 +1,43 @@
+package service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.FileNotFoundException;
+
+import static constant.SourcePath.BASIC_INDEX_PATH;
+import static org.junit.jupiter.api.Assertions.*;
+
+class FileServiceTest {
+    private String startTag = "<!DOCTYPE html>";
+
+    private FileService fileService;
+
+    @BeforeEach
+    void init() {
+        fileService = new FileService();
+    }
+
+    @Test
+    @DisplayName("위치에 있는 파일을 찾는다.")
+    void findFile() {
+        String basicIndexPath = BASIC_INDEX_PATH;
+
+        assertDoesNotThrow(() -> {
+            String fileContent = fileService.openFile(basicIndexPath);
+            assertTrue(fileContent.startsWith(startTag));
+        });
+    }
+
+    @Test
+    @DisplayName("위치에 있는 파일을 찾는다.")
+    void dontFindFile() {
+        String basicIndexPath = "/somewhere";
+
+        assertThrows(FileNotFoundException.class, () -> {
+            String fileContent = fileService.openFile(basicIndexPath);
+            assertTrue(fileContent.startsWith(startTag));
+        });
+    }
+}


### PR DESCRIPTION
## 구현 내용
- 첫 번째 파라미터 읽어오지 않던 현상 해결
- '.html'로 끝나는 uri 요청은 정적이 소스 파일을 반환하도록 처리
- 유저 정보 저장하는 기능
- Rest aussred 사용해 stream 영역 단 테스트 코드 작성

## 고민 사항
- 정적 파일 반환을 구현하기 전, 성태님께서 정적 요청은 따로 처리하지 하는 것이 좋겠다는 의견을 내주셨는데, 혹시나 요청과 실제 저장 경로가 다를 수도 있다고 생각했다. 하지만 step-3를 보고 경로가 다르지 않겠구나 합리적 확신을 했다.
- rest assured 라는 새로운 테스트 방법을 알았다. mock mvc와는 다르게 '서버 가동'을 하고 테스트를 진행하는 방법이다. 비용이 크다는 걸 제외하면 mock보다 훨씬 명시적인 테스트 방법이다. 좋은지 나쁜지는 둘 다 써보고 결정하겠다.

## 기타
- 빌더 패턴 적용하기
- mime 타입 enum으로 처리할 수 있도록!
- 조원 얘기 들어보니 지금 방식으로는 request body를 읽어오지 못 하는 이슈가 있다함. 수정해야 됨.