### PR TITLE
[신동우] step-1 index.html 응답

### DIFF
--- a/src/main/java/controllers/Controller.java
+++ b/src/main/java/controllers/Controller.java
@@ -1,0 +1,11 @@
+package controllers;
+
+import webserver.GetMapping;
+
+public class Controller {
+
+	@GetMapping("/")
+	public String getIndex() {
+		return "index.html";
+	}
+}

--- a/src/main/java/webserver/GetMapping.java
+++ b/src/main/java/webserver/GetMapping.java
@@ -1,0 +1,12 @@
+package webserver;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface GetMapping {
+	String value();
+}

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -1,55 +1,122 @@
 package webserver;
 
+import java.io.BufferedReader;
 import java.io.DataOutputStream;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.io.OutputStream;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
 import java.net.Socket;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class RequestHandler implements Runnable {
-    private static final Logger logger = LoggerFactory.getLogger(RequestHandler.class);
+	private static final Logger logger = LoggerFactory.getLogger(RequestHandler.class);
 
-    private Socket connection;
+	private Socket connection;
 
-    public RequestHandler(Socket connectionSocket) {
-        this.connection = connectionSocket;
-    }
+	public RequestHandler(Socket connectionSocket) {
+		this.connection = connectionSocket;
+	}
 
-    public void run() {
-        logger.debug("New Client Connect! Connected IP : {}, Port : {}", connection.getInetAddress(),
-                connection.getPort());
+	RequestHandler() {
+	}
 
-        try (InputStream in = connection.getInputStream(); OutputStream out = connection.getOutputStream()) {
-            // TODO 사용자 요청에 대한 처리는 이 곳에 구현하면 된다.
-            DataOutputStream dos = new DataOutputStream(out);
-            byte[] body = "Hello World".getBytes();
-            response200Header(dos, body.length);
-            responseBody(dos, body);
-        } catch (IOException e) {
-            logger.error(e.getMessage());
-        }
-    }
+	public void run() {
+		logger.debug("New Client Connect! Connected IP : {}, Port : {}", connection.getInetAddress(),
+			connection.getPort());
 
-    private void response200Header(DataOutputStream dos, int lengthOfBodyContent) {
-        try {
-            dos.writeBytes("HTTP/1.1 200 OK \r\n");
-            dos.writeBytes("Content-Type: text/html;charset=utf-8\r\n");
-            dos.writeBytes("Content-Length: " + lengthOfBodyContent + "\r\n");
-            dos.writeBytes("\r\n");
-        } catch (IOException e) {
-            logger.error(e.getMessage());
-        }
-    }
+		try (InputStream in = connection.getInputStream(); OutputStream out = connection.getOutputStream()) {
 
-    private void responseBody(DataOutputStream dos, byte[] body) {
-        try {
-            dos.write(body, 0, body.length);
-            dos.flush();
-        } catch (IOException e) {
-            logger.error(e.getMessage());
-        }
-    }
+			String line;
+			BufferedReader reader = new BufferedReader(new InputStreamReader(in));
+			while ((line = reader.readLine()) != null) {
+				logger.debug(line);
+				try {
+					if (line.startsWith("GET")) {
+						handleGetRequest(line, out);
+						return;
+					}
+				} catch (ReflectiveOperationException exception) {
+				}
+			}
+
+		} catch (IOException e) {
+			logger.error(e.getMessage());
+		}
+	}
+
+	private void handleGetRequest(String line, OutputStream out) throws ReflectiveOperationException, IOException {
+		String[] arguments;
+		if (line.startsWith("GET")) {
+			arguments = line.split(" ");
+			final Method[] declaredMethods = RequestHandler.class.getDeclaredMethods();
+			Constructor<RequestHandler> constructor = RequestHandler.class.getDeclaredConstructor();
+			Object o = constructor.newInstance();
+			List<Method> mappedMethods = Arrays.stream(declaredMethods)
+				.filter(method -> method.isAnnotationPresent(GetMapping.class) && method.getAnnotation(GetMapping.class)
+					.value()
+					.equals(arguments[1]))
+				.collect(Collectors.toList());
+			if (mappedMethods.isEmpty()) {
+				sendStaticResponse(arguments[1], out);
+				return;
+			}
+			for (Method mappedMethod : mappedMethods) {
+				sendTemplateResponse((String)mappedMethod.invoke(o), out);
+			}
+		}
+	}
+
+	private void sendTemplateResponse(String fileName, OutputStream out) throws IOException {
+		DataOutputStream dos = new DataOutputStream(out);
+		Path path = new File("src/main/resources/templates/" + fileName).toPath();
+		byte[] body = Files.readAllBytes(path);
+		String mimeType = Files.probeContentType(path);
+		response200Header(dos, body.length, mimeType);
+		responseBody(dos, body);
+	}
+
+	private void sendStaticResponse(String fileName, OutputStream out) throws IOException {
+		DataOutputStream dos = new DataOutputStream(out);
+		Path path = new File("src/main/resources/static" + fileName).toPath();
+		byte[] body = Files.readAllBytes(path);
+		String mimeType = Files.probeContentType(path);
+		response200Header(dos, body.length, mimeType);
+		responseBody(dos, body);
+	}
+
+	@GetMapping("/")
+	private String getFile() {
+		return "index.html";
+	}
+
+	private void response200Header(DataOutputStream dos, int lengthOfBodyContent, String mimeType) {
+		try {
+			dos.writeBytes("HTTP/1.1 200 OK \r\n");
+			dos.writeBytes("Content-Type: " + mimeType + ";charset=utf-8\r\n");
+			dos.writeBytes("Content-Length: " + lengthOfBodyContent + "\r\n");
+			dos.writeBytes("\r\n");
+		} catch (IOException e) {
+			logger.error(e.getMessage());
+		}
+	}
+
+	private void responseBody(DataOutputStream dos, byte[] body) {
+		try {
+			dos.write(body, 0, body.length);
+			dos.flush();
+		} catch (IOException e) {
+			logger.error(e.getMessage());
+		}
+	}
 }

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -19,6 +19,8 @@ import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import controllers.Controller;
+
 public class RequestHandler implements Runnable {
 	private static final Logger logger = LoggerFactory.getLogger(RequestHandler.class);
 
@@ -26,9 +28,6 @@ public class RequestHandler implements Runnable {
 
 	public RequestHandler(Socket connectionSocket) {
 		this.connection = connectionSocket;
-	}
-
-	RequestHandler() {
 	}
 
 	public void run() {
@@ -47,6 +46,8 @@ public class RequestHandler implements Runnable {
 						return;
 					}
 				} catch (ReflectiveOperationException exception) {
+					logger.warn("ReflectiveOperationException");
+					logger.warn(exception.getMessage());
 				}
 			}
 
@@ -59,8 +60,8 @@ public class RequestHandler implements Runnable {
 		String[] arguments;
 		if (line.startsWith("GET")) {
 			arguments = line.split(" ");
-			final Method[] declaredMethods = RequestHandler.class.getDeclaredMethods();
-			Constructor<RequestHandler> constructor = RequestHandler.class.getDeclaredConstructor();
+			final Method[] declaredMethods = Controller.class.getDeclaredMethods();
+			Constructor<Controller> constructor = Controller.class.getDeclaredConstructor();
 			Object o = constructor.newInstance();
 			List<Method> mappedMethods = Arrays.stream(declaredMethods)
 				.filter(method -> method.isAnnotationPresent(GetMapping.class) && method.getAnnotation(GetMapping.class)

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -96,11 +96,6 @@ public class RequestHandler implements Runnable {
 		responseBody(dos, body);
 	}
 
-	@GetMapping("/")
-	private String getFile() {
-		return "index.html";
-	}
-
 	private void response200Header(DataOutputStream dos, int lengthOfBodyContent, String mimeType) {
 		try {
 			dos.writeBytes("HTTP/1.1 200 OK \r\n");

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -74,22 +74,23 @@ public class RequestHandler implements Runnable {
 			}
 			for (Method mappedMethod : mappedMethods) {
 				sendTemplateResponse((String)mappedMethod.invoke(o), out);
+				return;
 			}
 		}
 	}
 
 	private void sendTemplateResponse(String fileName, OutputStream out) throws IOException {
-		DataOutputStream dos = new DataOutputStream(out);
 		Path path = new File("src/main/resources/templates/" + fileName).toPath();
-		byte[] body = Files.readAllBytes(path);
-		String mimeType = Files.probeContentType(path);
-		response200Header(dos, body.length, mimeType);
-		responseBody(dos, body);
+		responseForPath(out, path);
 	}
 
 	private void sendStaticResponse(String fileName, OutputStream out) throws IOException {
-		DataOutputStream dos = new DataOutputStream(out);
 		Path path = new File("src/main/resources/static" + fileName).toPath();
+		responseForPath(out, path);
+	}
+
+	private void responseForPath(OutputStream out, Path path) throws IOException {
+		DataOutputStream dos = new DataOutputStream(out);
 		byte[] body = Files.readAllBytes(path);
 		String mimeType = Files.probeContentType(path);
 		response200Header(dos, body.length, mimeType);

--- a/src/main/java/webserver/WebServer.java
+++ b/src/main/java/webserver/WebServer.java
@@ -2,6 +2,8 @@ package webserver;
 
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -25,8 +27,9 @@ public class WebServer {
             // 클라이언트가 연결될때까지 대기한다.
             Socket connection;
             while ((connection = listenSocket.accept()) != null) {
-                Thread thread = new Thread(new RequestHandler(connection));
-                thread.start();
+                Runnable requestHandler = new RequestHandler(connection);
+                ExecutorService executors = Executors.newFixedThreadPool(10);
+                executors.execute(requestHandler);
             }
         }
     }

--- a/src/main/java/webserver/WebServer.java
+++ b/src/main/java/webserver/WebServer.java
@@ -10,7 +10,7 @@ public class WebServer {
     private static final Logger logger = LoggerFactory.getLogger(WebServer.class);
     private static final int DEFAULT_PORT = 8080;
 
-    public static void main(String args[]) throws Exception {
+    public static void main(String[] args) throws Exception {
         int port = 0;
         if (args == null || args.length == 0) {
             port = DEFAULT_PORT;
@@ -30,4 +30,5 @@ public class WebServer {
             }
         }
     }
+
 }

--- a/src/main/java/webserver/WebServer.java
+++ b/src/main/java/webserver/WebServer.java
@@ -28,7 +28,7 @@ public class WebServer {
             Socket connection;
             while ((connection = listenSocket.accept()) != null) {
                 Runnable requestHandler = new RequestHandler(connection);
-                ExecutorService executors = Executors.newFixedThreadPool(10);
+                ExecutorService executors = Executors.newWorkStealingPool();
                 executors.submit(requestHandler);
             }
         }

--- a/src/main/java/webserver/WebServer.java
+++ b/src/main/java/webserver/WebServer.java
@@ -29,7 +29,7 @@ public class WebServer {
             while ((connection = listenSocket.accept()) != null) {
                 Runnable requestHandler = new RequestHandler(connection);
                 ExecutorService executors = Executors.newFixedThreadPool(10);
-                executors.execute(requestHandler);
+                executors.submit(requestHandler);
             }
         }
     }


### PR DESCRIPTION
## 구현 내용
- [x] **정적 파일 응답**
  url을 통해 접속했을 때 디렉토리의 해당하는 파일을 클라이언트에게 응답할 수 있다.

- [x] **HTTP Request 내용 Logger 출력** 
  서버로 들어오는 HTTP Request의 내용을 Logger로 출력할 수 있다.

- [x] **Thread기반 프로젝트를 Concurrent 패키지를 사용하도록 변경**
  ExecutorService 인터페이스를 사용해 스레드 풀을 사용하도록 변경했다. 

## 고민 사항
- 어떤 Thread pool을 사용해야 할 지, Thread의 개수는 몇 개로 설정해야 할 지
  처음 WebServer 클래스를 수정할 땐 newFixedThreadPool(10)으로 시스템 코어 수와 동일하게 설정했었다. 성태님이 WorkStealingPool을 알려주셔서 사용해보니 스레드의 부하가 균형있게 분산되는 방식으로 성능을 높일 수 있었다. 스레드에 인터럽트를 보낼 일도 없다고 생각해 WorkStealingPool로 결정했다.

- 지표로 결과가 확인 가능한 성능, 부하 테스트 방법
  postman으로 테스트를 진행했는데, 분명 workstealingpool로 변경하면서 성능이 올라갔음을 확인하긴했지만 비교할만한 지표를 확인할 수 있는 부하 테스트 방법을 찾지 못했다.

- ExecutorService execute(), submit() ?
  submit을 사용하면 결과를 받을 수 있다는 차이점도 있지만, 예외 발생 시 execute는 스레드를 없애고 제외시키지만 submit은 예외가 발생해도 스레드를 없애지 않고 재활용해 오버헤드가 적다고 한다. 그렇다면 거의 모든 상황에서 submit을 사용하는게 더 좋을 것 같은데 execute를 따로 사용하는 상황이 있는 것인지, 그저 deprecated된 방식인지 궁금하다.

## 기타
