### PR TITLE
[박선미] step-3 다양한 컨텐츠 타입 지원

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,18 @@ Java Web Application Server 2023
   - HTTP RequestURI, Request, Response, Header 캡슐화
   - REST API Controller 생성
   - 404 에러, 400 에러 처리
+  - request uri, resource path 상수 분리하여 관리
+  -> 요청 경로와 실제 경로가 같다는 가정하에 정적인 파일 response 할 수 있도
+  - Thread -> concurrent 메소드로 이동
+  - request line에서의 query parameter 저장
+  - MIME enum 클래스 추가
+  - 다양한 Content-Type 지원하도록
 
 - 해야 할 일
-  - Thread -> concurrent 패키지로 옮기기
-  - CSS 잘 나오게 수정
   - HTTP wiki에 정리
   - HttpResponse Builder 패턴 적용하기
-  - HttpResponse Header 생성하는 부분 어떻게 깔끔하게 구현할지 생각하기
+  - IO stream 읽고 쓰는 방식 처리할 방법 고민
+  - 테스트 코드 작성..
 
 ### 메모
+- request body 읽어오도록 수정

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter:5.8.1'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
     testImplementation 'org.assertj:assertj-core:3.16.1'
-
+    testImplementation 'io.rest-assured:rest-assured:5.3.1'
 }
 
 test {

--- a/src/main/java/constant/SourcePath.java
+++ b/src/main/java/constant/SourcePath.java
@@ -1,11 +1,6 @@
 package constant;
 
 public class SourcePath {
-    public static final String BASIC_INDEX_PATH = "/index.html";
-    public static final String USER_FORM_PATH = "/user/form.html";
-    private static final String RESOURCE_RELATIVE_PATH = "src/main/resources/templates";
-
-    public static String getRelativePath(String path) {
-        return RESOURCE_RELATIVE_PATH + path;
-    }
+    public static final String RESOURCE_TEMPLATE_RELATIVE_PATH = "src/main/resources/templates";
+    public static final String RESOURCE_STATIC_RELATIVE_PATH = "src/main/resources/static";
 }

--- a/src/main/java/constant/Uri.java
+++ b/src/main/java/constant/Uri.java
@@ -1,9 +1,5 @@
 package constant;
 
 public class Uri {
-    public static final String BASIC_INDEX_URI = "/index.html";
-    public static final String USER_FORM_URI = "/user/form.html";
-
     public static final String USER_CREATE_URI = "/user/create";
-
 }

--- a/src/main/java/mapper/ResponseMapper.java
+++ b/src/main/java/mapper/ResponseMapper.java
@@ -3,20 +3,21 @@ package mapper;
 import model.HttpRequest;
 import model.HttpResponse;
 import model.enums.HttpStatusCode;
+import model.enums.MIME;
 
 public class ResponseMapper {
     private static final String PAGE_NOT_FOUND = "요청하신 페이지가 없습니다.";
     private static final String PAGE_BAD_REQUEST = "잘못된 요청입니다.";
 
-    public HttpResponse createHttpResponse(HttpRequest request, HttpStatusCode statusCode, String body) {
-        return HttpResponse.of(request, statusCode, body);
+    public HttpResponse createHttpResponse(HttpRequest request, HttpStatusCode statusCode, String body, MIME extension) {
+        return HttpResponse.of(request, statusCode, body, extension);
     }
 
     public HttpResponse createNotFoundResponse(HttpRequest httpRequest) {
-        return createHttpResponse(httpRequest, HttpStatusCode.NOT_FOUND, PAGE_NOT_FOUND);
+        return createHttpResponse(httpRequest, HttpStatusCode.NOT_FOUND, PAGE_NOT_FOUND, MIME.JSON);
     }
 
     public HttpResponse createBadRequestResponse(HttpRequest httpRequest) {
-        return createHttpResponse(httpRequest, HttpStatusCode.BAD_REQUEST, PAGE_BAD_REQUEST);
+        return createHttpResponse(httpRequest, HttpStatusCode.BAD_REQUEST, PAGE_BAD_REQUEST, MIME.JSON);
     }
 }

--- a/src/main/java/model/HttpRequest.java
+++ b/src/main/java/model/HttpRequest.java
@@ -4,7 +4,6 @@ import dto.UserFormRequestDto;
 import model.enums.Method;
 
 public class HttpRequest {
-    public static final String HTML_FILE_FORMAT = ".html";
     private final RequestUri requestUri;
     private final String protocol;
     private final Method method;
@@ -27,16 +26,12 @@ public class HttpRequest {
         return this.method == method;
     }
 
-    public HttpHeader getHeader() {
-        return httpHeader.newInstance();
-    }
-
     public String getProtocol() {
         return this.protocol;
     }
 
-    public boolean endsWithHtml() {
-        return requestUri.uriEndsWith(HTML_FILE_FORMAT);
+    public boolean isUriStaticFile() {
+        return requestUri.isUriStaticFile();
     }
 
     public String getUri() {

--- a/src/main/java/model/HttpResponse.java
+++ b/src/main/java/model/HttpResponse.java
@@ -1,6 +1,7 @@
 package model;
 
 import model.enums.HttpStatusCode;
+import model.enums.MIME;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -22,12 +23,11 @@ public class HttpResponse {
         this.body = body;
     }
 
-    public static HttpResponse of(HttpRequest httpRequest, HttpStatusCode statusCode, String body) {
+    public static HttpResponse of(HttpRequest httpRequest, HttpStatusCode statusCode, String body, MIME extension) {
         Map<String, String> header = new HashMap<>();
         int lengthOfBody = body.getBytes().length;
 
-        // TODO 수정하기
-        header.put("Content-Type", "text/html;charset=utf-8");
+        header.put("Content-Type", extension.getContentType());
         header.put("Content-Length", String.valueOf(lengthOfBody));
         HttpHeader httpHeader = HttpHeader.of(header);
 

--- a/src/main/java/model/RequestUri.java
+++ b/src/main/java/model/RequestUri.java
@@ -13,6 +13,7 @@ public class RequestUri {
     private static final int URI_INDEX = 0;
     private static final int PARAMETERS_INDEX = 1;
     private static final int LENGTH_WHEN_HAS_NO_VALUE = 1;
+    private static final String COMMA = ".";
 
     private final String uri;
     private final Map<String, Object> params;
@@ -51,8 +52,8 @@ public class RequestUri {
         return this.uri.equals(uri);
     }
 
-    public boolean uriEndsWith(String s) {
-        return uri.endsWith(s);
+    public boolean isUriStaticFile() {
+        return uri.contains(COMMA);
     }
 
     public String getUri() {

--- a/src/main/java/model/enums/MIME.java
+++ b/src/main/java/model/enums/MIME.java
@@ -1,0 +1,26 @@
+package model.enums;
+
+public enum MIME {
+    HTML("text/html"),
+    CSS("text/css"),
+    JS("text/js"),
+    ICO("image/x-icon"),
+    PNG("image/png"),
+    JPG("image/jpg"),
+    JSON("application/json"),
+    ;
+
+    private final String contentType;
+
+    MIME(String contentType) {
+        this.contentType = contentType;
+    }
+
+    public String getContentType() {
+        return this.contentType;
+    }
+
+    public boolean isHTML() {
+        return this == HTML;
+    }
+}

--- a/src/main/java/service/FileService.java
+++ b/src/main/java/service/FileService.java
@@ -1,18 +1,29 @@
 package service;
 
-import model.HttpRequest;
-import model.HttpResponse;
-import model.enums.HttpStatusCode;
+import model.enums.MIME;
 
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.util.Scanner;
 
-import static constant.SourcePath.getRelativePath;
+import static constant.SourcePath.RESOURCE_STATIC_RELATIVE_PATH;
+import static constant.SourcePath.RESOURCE_TEMPLATE_RELATIVE_PATH;
 
 public class FileService {
-    public String openFile(String path) throws FileNotFoundException {
-        String resourcePath = getRelativePath(path);
+    public String openFile(String path, MIME extension) throws FileNotFoundException {
+        if (extension.isHTML()) {
+            return openTemplate(path);
+        }
+        return openStatic(path);
+    }
+
+    private String openStatic(String path) throws FileNotFoundException {
+        String resourcePath = RESOURCE_STATIC_RELATIVE_PATH + path;
+        return getFileIn(resourcePath);
+    }
+
+    private String openTemplate(String path) throws FileNotFoundException {
+        String resourcePath = RESOURCE_TEMPLATE_RELATIVE_PATH + path;
         return getFileIn(resourcePath);
     }
 

--- a/src/main/java/util/StringUtils.java
+++ b/src/main/java/util/StringUtils.java
@@ -12,6 +12,7 @@ public class StringUtils {
     public static final String AMPERSAND_MARK = "&";
     public static final String EQUAL_MARK = "=";
     public static final String COLON_MARK = ":";
+    public static final String COMMA_MARK = "\\.";
 
     public static String[] splitBy(String text, String regex){
         return text.split(regex);

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -27,7 +27,6 @@ public class RequestHandler implements Runnable {
                 connection.getPort());
 
         try (InputStream in = connection.getInputStream(); OutputStream out = connection.getOutputStream()) {
-
             BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8));
             HttpRequest httpRequest = Parser.getHttpRequest(bufferedReader);
 

--- a/src/main/java/webserver/WebServer.java
+++ b/src/main/java/webserver/WebServer.java
@@ -34,6 +34,5 @@ public class WebServer {
         } catch(Exception e) {
             logger.debug(e.getMessage());
         }
-
     }
 }

--- a/src/test/java/webserver/RequestHandlerTest.java
+++ b/src/test/java/webserver/RequestHandlerTest.java
@@ -1,0 +1,53 @@
+package webserver;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static constant.Uri.USER_CREATE_URI;
+import static io.restassured.RestAssured.DEFAULT_PORT;
+import static io.restassured.RestAssured.given;
+import static model.enums.HttpStatusCode.*;
+
+class RequestHandlerTest {
+    private final int PORT = DEFAULT_PORT;
+
+    @Test
+    @DisplayName("index.html 요청 테스트")
+    void htmlRequestTest() {
+        given()
+            .port(PORT)
+        .when()
+            .get("/index.html")
+        .then()
+            .statusCode(OK.getValue());
+    }
+
+    @Test
+    @DisplayName("index.html 요청 테스트")
+    void htmlRequestFailTest() {
+        // TODO rest assured
+        given()
+        .when()
+            .get("/any.html")
+        .then()
+            .statusCode(BAD_REQUEST.getValue());
+    }
+
+    @Test
+    @DisplayName("/user/create 요청 테스트")
+    void requestCreateUser() {
+        String uri = USER_CREATE_URI;
+        given()
+            .port(PORT)
+                .param("name", "kim")
+                .param("email", "a@a.a")
+                .param("userId", "id")
+                .param("password", "pawd")
+        .when()
+            .get(uri)
+        .then()
+            .statusCode(CREATED.getValue());
+    }
+}


### PR DESCRIPTION
## 구현 내용
- MIME 타입 enum 클래스 생성
- 헤더 가변인자로 생성할 수 있도록 리팩토링
- 스태틱 파일인지 확인 분기점 생성 -> 스태틱 파일이면 서버가 제공하는 확장자인지 확인하고 맞으면 파일 리턴
- rest assured 테스트 처음 사용...!

## 고민 사항
- 버퍼로 request를 입력 받아 오는 역할을 어디에 줘야 하는지 고민했다. 이건 아직까지 결정을 못해서 util.parser에 넣어놨다...
- 요청이 많아질수록 RestController의 route 메소드에 if문이 추가될텐데 이걸 어떻게 처리하면 좋을지 고민 중이다. 어노테이션을 만들고 싶진 않은데 또 커스텀 어노테이션은 만들어 보고 싶고ㅋㅋ

## 기타
- 헤더의 `Content-Type`이 렌더링에 영향을 미친다는 것을 처음 알았다. 맨날 잘 구현된 프레임워크만 쓰다가 하나하나 해보려니까 알아가는 것이 많다.
