### PR TITLE
[최규현] step-3 다양한 컨텐츠 타입 지원

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,12 @@ Java Web Application Server 2023
   - [x] Dispatcher Servlet 구현
 #### Web Server step-3
 - 다양한 Content-Type 지원하도록 구현
-  - [ ] html
-  - [ ] css
-  - [ ] js
-  - [ ] ico
-  - [ ] png
-  - [ ] jpg 
+  - [x] html
+  - [x] css
+  - [x] js
+  - [x] ico
+  - [x] png
+  - [x] jpg 
 
 ## To Study List
 #### Web Server step-1

--- a/README.md
+++ b/README.md
@@ -21,8 +21,10 @@ Java Web Application Server 2023
 - [x] Java Thread 기반에서 Concurrent 패키지 사용하도록 수정
 - [x] Github 위키에 학습 내용 기록
 #### Web Server step-2
-- [ ] GET을 통한 회원가입 구현
-
+- [x] GET을 통한 회원가입 구현
+  - [x] Dispatcher Servlet 구현
+#### Web Server step-3
+- [ ] 다양한 Content-Type 지원하도록 구현
 
 ## To Study List
 #### Web Server step-1
@@ -33,3 +35,4 @@ Java Web Application Server 2023
   - [x] Concurrent 패키지 학습
 #### Web Server step-2
 - [x] GET 프로토콜 이해하기
+#### Web Server step-3

--- a/README.md
+++ b/README.md
@@ -36,3 +36,4 @@ Java Web Application Server 2023
 #### Web Server step-2
 - [x] GET 프로토콜 이해하기
 #### Web Server step-3
+- [ ] MIME 타입 이해하기

--- a/README.md
+++ b/README.md
@@ -24,7 +24,13 @@ Java Web Application Server 2023
 - [x] GET을 통한 회원가입 구현
   - [x] Dispatcher Servlet 구현
 #### Web Server step-3
-- [ ] 다양한 Content-Type 지원하도록 구현
+- 다양한 Content-Type 지원하도록 구현
+  - [ ] html
+  - [ ] css
+  - [ ] js
+  - [ ] ico
+  - [ ] png
+  - [ ] jpg 
 
 ## To Study List
 #### Web Server step-1
@@ -36,4 +42,4 @@ Java Web Application Server 2023
 #### Web Server step-2
 - [x] GET 프로토콜 이해하기
 #### Web Server step-3
-- [ ] MIME 타입 이해하기
+- [x] MIME 타입 이해하기

--- a/src/main/java/controller/Controller.java
+++ b/src/main/java/controller/Controller.java
@@ -3,6 +3,7 @@ package controller;
 import annotation.GetMapping;
 import db.Database;
 import model.User;
+import model.dto.UserFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import webserver.RequestHandler;
@@ -19,22 +20,10 @@ public class Controller {
     public HttpResponse createUser(Map<String, String> query) throws IOException {
         logger.debug("GET user/create API START");
 
-        // TODO : Service layer 분리
-        String userId = query.get("userId");
-        String password = query.get("password");
-        String name = query.get("name");
-        String email = query.get("email");
-
-        User user = new User(userId, password, name, email);
+        User user = UserFactory.createUserFrom(query);
         Database.addUser(user);
-
-        logger.debug("user 생성 : {}", Database.findUserById(userId));
+        logger.debug("user 생성 : {}", Database.findUserById(query.get("userId")));
 
         return HttpResponse.redirect();
-    }
-
-    @GetMapping(value = "/test")
-    public HttpResponse test() throws IOException {
-        return null;
     }
 }

--- a/src/main/java/controller/Controller.java
+++ b/src/main/java/controller/Controller.java
@@ -3,12 +3,9 @@ package controller;
 import annotation.GetMapping;
 import db.Database;
 import model.User;
-import model.dto.UserFactory;
+import model.factory.UserFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import webserver.RequestHandler;
-import webserver.http.request.HttpRequest;
-import webserver.http.response.HttpResponse;
 
 import java.io.IOException;
 import java.util.Map;
@@ -17,13 +14,13 @@ public class Controller {
     private static final Logger logger = LoggerFactory.getLogger(Controller.class);
 
     @GetMapping(value = "/user/create")
-    public HttpResponse createUser(Map<String, String> query) throws IOException {
+    public String createUser(Map<String, String> query) throws IOException {
         logger.debug("GET user/create API START");
 
         User user = UserFactory.createUserFrom(query);
         Database.addUser(user);
         logger.debug("user 생성 : {}", Database.findUserById(query.get("userId")));
 
-        return HttpResponse.redirect();
+        return "/index.html"; // TODO String으로 변경 (reflection)
     }
 }

--- a/src/main/java/controller/Controller.java
+++ b/src/main/java/controller/Controller.java
@@ -14,13 +14,13 @@ public class Controller {
     private static final Logger logger = LoggerFactory.getLogger(Controller.class);
 
     @GetMapping(value = "/user/create")
-    public String createUser(Map<String, String> query) throws IOException {
+    public String createUser(Map<String, String> query){
         logger.debug("GET user/create API START");
 
         User user = UserFactory.createUserFrom(query);
         Database.addUser(user);
         logger.debug("user 생성 : {}", Database.findUserById(query.get("userId")));
 
-        return "/index.html"; // TODO String으로 변경 (reflection)
+        return "/index.html";
     }
 }

--- a/src/main/java/model/dto/UserFactory.java
+++ b/src/main/java/model/dto/UserFactory.java
@@ -1,0 +1,18 @@
+package model.dto;
+
+import model.User;
+
+import java.util.Map;
+
+public class UserFactory {
+    private UserFactory() {
+    }
+
+    public static User createUserFrom(Map<String, String> query){
+        String userId = query.get("userId");
+        String password = query.get("password");
+        String name = query.get("name");
+        String email = query.get("email");
+        return new User(userId, password, name, email);
+    }
+}

--- a/src/main/java/model/factory/UserFactory.java
+++ b/src/main/java/model/factory/UserFactory.java
@@ -1,4 +1,4 @@
-package model.dto;
+package model.factory;
 
 import model.User;
 

--- a/src/main/java/webserver/ContentType.java
+++ b/src/main/java/webserver/ContentType.java
@@ -1,0 +1,43 @@
+package webserver;
+
+import java.util.Arrays;
+
+public enum ContentType {
+    HTML("html", "/templates", "text/html"),
+    CSS("css", "/static", "text/css"),
+    JS("js", "/static", "text/javascript"),
+    ICO("ico", "/static", "image/x-icon"),
+    PNG("png", "/static", "image/png"),
+    JPG("jpg", "/static", "image/jpeg"),
+    NONE("", "", ""),
+    ;
+
+    private String value;
+    private String path;
+    private String mime;
+
+    ContentType(String value, String path, String mime) {
+        this.value = value;
+        this.path = path;
+        this.mime = mime;
+    }
+
+    public static ContentType findBy(String file){
+        return Arrays.stream(values())
+                .filter(type -> file.endsWith(type.value))
+                .findFirst()
+                .orElse(NONE);
+    }
+
+    public String mapResourceFolders(String file){
+        return this.path + file;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    public String getMime() {
+        return mime;
+    }
+}

--- a/src/main/java/webserver/DispatcherServlet.java
+++ b/src/main/java/webserver/DispatcherServlet.java
@@ -41,7 +41,7 @@ public class DispatcherServlet {
         if (hasRequestPathMapped(method)) {
             path = executeRequest(request, method);
         }
-        findStaticFile(response, path);
+        findResources(response, path);
     }
 
     private static boolean hasRequestPathMapped(Method method) {
@@ -59,8 +59,10 @@ public class DispatcherServlet {
         return path;
     }
 
-    private void findStaticFile(HttpResponse response, String filePath) {
+    private void findResources(HttpResponse response, String filePath) {
         try {
+            ContentType type = ContentType.findBy(filePath);
+            filePath = type.mapResourceFolders(filePath);
             response.setResults(filePath, OK);
         } catch (IOException e) {
             logger.debug("readAllBytes ERROR");
@@ -82,7 +84,8 @@ public class DispatcherServlet {
         return method.getParameterCount() != 0;
     }
 
-    public void processDispatchServlet(OutputStream out, HttpResponse response) {
-        response.writeResponseToOutputStream(out);
+    public void processDispatchServlet(HttpRequest request, HttpResponse response, OutputStream out) {
+        ContentType type = ContentType.findBy(request.getPath());
+        response.writeResponseToOutputStream(out, type);
     }
 }

--- a/src/main/java/webserver/DispatcherServlet.java
+++ b/src/main/java/webserver/DispatcherServlet.java
@@ -83,6 +83,6 @@ public class DispatcherServlet {
     }
 
     public void processDispatchServlet(OutputStream out, HttpResponse response) {
-        response.response(out);
+        response.writeResponseToOutputStream(out);
     }
 }

--- a/src/main/java/webserver/HandlerMapping.java
+++ b/src/main/java/webserver/HandlerMapping.java
@@ -10,7 +10,6 @@ import java.util.Map;
 
 public class HandlerMapping {
     public static Map<String, Method> GETMap = new HashMap<>();;
-
     static{
         Method[] methods = Controller.class.getMethods();
         for (Method method : methods) {

--- a/src/main/java/webserver/HandlerMapping.java
+++ b/src/main/java/webserver/HandlerMapping.java
@@ -23,7 +23,7 @@ public class HandlerMapping {
     private HandlerMapping() {
     }
 
-    public static Method getHandler(HttpRequest request){
+    public static Method getMethodMapped(HttpRequest request){
         return GETMap.getOrDefault(request.getPath(), null);
     }
 }

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -24,10 +24,14 @@ public class RequestHandler implements Runnable {
                 connection.getPort());
 
         try (InputStream in = connection.getInputStream(); OutputStream out = connection.getOutputStream()) {
-            DispatcherServlet dispatcherServlet = new DispatcherServlet();
-            dispatcherServlet.doService(in, out);
+            HttpRequest request = HttpRequest.from(in);
+            HttpResponse response = HttpResponse.init();
+
+            DispatcherServlet dispatcherServlet = DispatcherServlet.init();
+            dispatcherServlet.doService(request, response);
+            dispatcherServlet.processDispatchServlet(out, response);
         } catch (IOException e){
-            // TODO : Redirect 로직 다시 구성 (여기서 리다이렉트 시킬 수 있게 하기)
+            logger.debug("readAllBytes ERROR");
         }
         catch (Throwable e) {
             logger.error(e.getMessage());

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -29,7 +29,7 @@ public class RequestHandler implements Runnable {
 
             DispatcherServlet dispatcherServlet = DispatcherServlet.init();
             dispatcherServlet.doService(request, response);
-            dispatcherServlet.processDispatchServlet(out, response);
+            dispatcherServlet.processDispatchServlet(request, response, out);
         } catch (IOException e){
             logger.debug("readAllBytes ERROR");
         }

--- a/src/main/java/webserver/http/request/HttpRequest.java
+++ b/src/main/java/webserver/http/request/HttpRequest.java
@@ -4,6 +4,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.StringTokenizer;
@@ -16,7 +17,7 @@ public class HttpRequest {
     private final Map<String, String> header = new HashMap<>();
 
     private HttpRequest(InputStream in) throws IOException {
-        BufferedReader br = new BufferedReader(new InputStreamReader(in));
+        BufferedReader br = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8));
         String line = br.readLine();
         this.requestLine = HttpRequestLine.from(line);
 

--- a/src/main/java/webserver/http/request/HttpRequest.java
+++ b/src/main/java/webserver/http/request/HttpRequest.java
@@ -13,7 +13,6 @@ import static utils.StringUtils.*;
 
 public class HttpRequest {
     private final HttpRequestLine requestLine;
-    private final String HTML = "html";
     private final Map<String, String> header = new HashMap<>();
 
     private HttpRequest(InputStream in) throws IOException {

--- a/src/main/java/webserver/http/response/HttpResponse.java
+++ b/src/main/java/webserver/http/response/HttpResponse.java
@@ -2,6 +2,7 @@ package webserver.http.response;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import webserver.ContentType;
 import webserver.http.HttpStatus;
 
 import java.io.DataOutputStream;
@@ -14,7 +15,7 @@ import static webserver.http.HttpStatus.*;
 
 public class HttpResponse {
     private static final Logger logger = LoggerFactory.getLogger(HttpResponse.class);
-    private final String PATH = "src/main/resources/templates";
+    private final String PATH = "src/main/resources";
     private byte[] body;
     private HttpStatus status;
 
@@ -25,11 +26,11 @@ public class HttpResponse {
         return new HttpResponse();
     }
 
-    public void writeResponseToOutputStream(OutputStream out){
+    public void writeResponseToOutputStream(OutputStream out, ContentType type){
         DataOutputStream dos = new DataOutputStream(out);
 
         if(status == OK){
-            response200Header(dos);
+            response200Header(dos, type);
         }
 //        else if(status == BAD_REQUEST){
 //            response400Header(dos);
@@ -40,17 +41,17 @@ public class HttpResponse {
         responseBody(dos);
     }
 
-    private void response404Header(DataOutputStream dos) {
-    }
+//    private void response404Header(DataOutputStream dos) {
+//    }
+//
+//    private void response400Header(DataOutputStream dos) {
+//
+//    }
 
-    private void response400Header(DataOutputStream dos) {
-    
-    }
-
-    private void response200Header(DataOutputStream dos) {
+    private void response200Header(DataOutputStream dos, ContentType type) {
         try {
             dos.writeBytes("HTTP/1.1 200 OK \r\n");
-            dos.writeBytes("Content-Type: text/html;charset=utf-8\r\n");
+            dos.writeBytes(String.format("Content-Type: %s;charset=utf-8\r\n", type.getMime()));
             dos.writeBytes("Content-Length: " + body.length + "\r\n");
             dos.writeBytes("\r\n");
         } catch (IOException e) {

--- a/src/main/java/webserver/http/response/HttpResponse.java
+++ b/src/main/java/webserver/http/response/HttpResponse.java
@@ -25,7 +25,7 @@ public class HttpResponse {
         return new HttpResponse();
     }
 
-    public void response(OutputStream out){
+    public void writeResponseToOutputStream(OutputStream out){
         DataOutputStream dos = new DataOutputStream(out);
 
         if(status == OK){

--- a/src/main/java/webserver/http/response/HttpResponse.java
+++ b/src/main/java/webserver/http/response/HttpResponse.java
@@ -15,23 +15,14 @@ import static webserver.http.HttpStatus.*;
 public class HttpResponse {
     private static final Logger logger = LoggerFactory.getLogger(HttpResponse.class);
     private final String PATH = "src/main/resources/templates";
-
+    private byte[] body;
     private HttpStatus status;
-    private final String filePath;
-    private final byte[] body;
 
-    private HttpResponse(HttpStatus status, String filePath) throws IOException {
-        this.status = status;
-        this.filePath = filePath;
-        this.body = Files.readAllBytes(new File(PATH + filePath).toPath());
+    private HttpResponse() {
     }
 
-    public static HttpResponse redirect() throws IOException {
-        return new HttpResponse(OK, "/index.html");
-    }
-
-    public static HttpResponse findStatic(String resource) throws IOException {
-        return new HttpResponse(OK, resource);
+    public static HttpResponse init() {
+        return new HttpResponse();
     }
 
     public void response(OutputStream out){
@@ -74,5 +65,15 @@ public class HttpResponse {
         } catch (IOException e) {
             logger.error(e.getMessage());
         }
+    }
+
+    public void setResults(String filePath, HttpStatus status) throws IOException {
+        byte[] body = convertFilePathToBody(filePath);
+        this.body = body;
+        this.status = status;
+    }
+
+    private byte[] convertFilePathToBody(String filePath) throws IOException {
+        return Files.readAllBytes(new File(PATH + filePath).toPath());
     }
 }

--- a/src/main/resources/templates/error.html
+++ b/src/main/resources/templates/error.html
@@ -5,6 +5,31 @@
     <title>👀NOT FOUND 404👀</title>
 </head>
 <body>
-
+<h1>
+    👀NOT FOUND 404👀 <br>
+    👀NOT FOUND 404👀 <br>
+    👀NOT FOUND 404👀 <br>
+    👀NOT FOUND 404👀 <br>
+    👀NOT FOUND 404👀 <br>
+    👀NOT FOUND 404👀 <br>
+    👀NOT FOUND 404👀 <br>
+    👀NOT FOUND 404👀 <br>
+    👀NOT FOUND 404👀 <br>
+    👀NOT FOUND 404👀 <br>
+    👀NOT FOUND 404👀 <br>
+    👀NOT FOUND 404👀 <br>
+    👀NOT FOUND 404👀 <br>
+    👀NOT FOUND 404👀 <br>
+    👀NOT FOUND 404👀 <br>
+    👀NOT FOUND 404👀 <br>
+    👀NOT FOUND 404👀 <br>
+    👀NOT FOUND 404👀 <br>
+    👀NOT FOUND 404👀 <br>
+    👀NOT FOUND 404👀 <br>
+    👀NOT FOUND 404👀 <br>
+    👀NOT FOUND 404👀 <br>
+    👀NOT FOUND 404👀 <br>
+    👀NOT FOUND 404👀 <br>
+</h1>
 </body>
 </html>

--- a/src/main/resources/templates/error.html
+++ b/src/main/resources/templates/error.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>👀NOT FOUND 404👀</title>
+</head>
+<body>
+
+</body>
+</html>

--- a/src/test/java/webserver/ContentTypeTest.java
+++ b/src/test/java/webserver/ContentTypeTest.java
@@ -1,0 +1,122 @@
+package webserver;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static webserver.ContentType.*;
+
+class ContentTypeTest {
+    @Test
+    @DisplayName("file에 해당하는 ContentType을 가져온다")
+    void findBy(){
+        // given
+        final String request = "/index.html";
+
+        // when
+        ContentType type = ContentType.findBy(request);
+
+        // then
+        assertEquals(HTML, type);
+    }
+
+    @Test
+    @DisplayName("지원하지 않는 ContentType이면 NONE을 가져온다")
+    void findNone(){
+        // given
+        final String request = "/hard.exe";
+
+        // when
+        ContentType type = ContentType.findBy(request);
+
+        // then
+        assertEquals(NONE, type);
+    }
+
+    @Test
+    @DisplayName("HTML 파일의 폴더 위치를 매핑한다")
+    void mapHTML(){
+        // given
+        final String request = "/index.html";
+        final ContentType html = HTML;
+
+        // when
+        final String filePath = html.mapResourceFolders(request);
+
+        // then
+        assertEquals(HTML.getPath() + request, filePath);
+    }
+
+    @Test
+    @DisplayName("CSS 파일의 폴더 위치를 매핑한다")
+    void mapCSS(){
+        // given
+        final String request = "/index.css";
+        final ContentType css = CSS;
+
+        // when
+        final String filePath = css.mapResourceFolders(request);
+
+        // then
+        assertEquals(CSS.getPath() + request, filePath);
+    }
+
+    @Test
+    @DisplayName("JS 파일의 폴더 위치를 매핑한다")
+    void mapJS(){
+        // given
+        final String request = "/index.js";
+        final ContentType js = JS;
+
+        // when
+        final String filePath = js.mapResourceFolders(request);
+
+        // then
+        assertEquals(JS.getPath() + request, filePath);
+    }
+
+    @Test
+    @DisplayName("ICO 파일의 폴더 위치를 매핑한다")
+    void mapICO(){
+        // given
+        final String request = "/index.ico";
+        final ContentType ico = ICO;
+
+        // when
+        final String filePath = ico.mapResourceFolders(request);
+
+        // then
+        assertEquals(ICO.getPath() + request, filePath);
+    }
+
+
+    @Test
+    @DisplayName("PNG 파일의 폴더 위치를 매핑한다")
+    void mapPNG(){
+        // given
+        final String request = "/index.png";
+        final ContentType png = PNG;
+
+        // when
+        final String filePath = png.mapResourceFolders(request);
+
+        // then
+        assertEquals(PNG.getPath() + request, filePath);
+    }
+
+
+    @Test
+    @DisplayName("JPG 파일의 폴더 위치를 매핑한다")
+    void mapJPG(){
+        // given
+        final String request = "/index.jpg";
+        final ContentType jpg = JPG;
+
+        // when
+        final String filePath = jpg.mapResourceFolders(request);
+
+        // then
+        assertEquals(JPG.getPath() + request, filePath);
+    }
+}

--- a/src/test/java/webserver/DispatcherServletTest.java
+++ b/src/test/java/webserver/DispatcherServletTest.java
@@ -1,24 +1,15 @@
 package webserver;
 
-import controller.Controller;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import webserver.http.request.HttpRequest;
 import webserver.http.request.Uri;
-import webserver.http.response.HttpResponse;
 
 import java.io.ByteArrayInputStream;
-import java.io.IOException;
 import java.io.InputStream;
-import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodHandles;
-import java.lang.invoke.MethodType;
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.Map;
 
-import static org.junit.jupiter.api.Assertions.*;
 import static utils.StringUtils.appendNewLine;
 
 class DispatcherServletTest {
@@ -47,8 +38,8 @@ class DispatcherServletTest {
         HttpRequest request = HttpRequest.from(in);
 
         //
-        Method method = HandlerMapping.getHandler(request);
-        DispatcherServlet tmp = new DispatcherServlet();
+        Method method = HandlerMapping.getMethodMapped(request);
+        DispatcherServlet tmp = DispatcherServlet.init();
 
         // then
 

--- a/src/test/java/webserver/DispatcherServletTest.java
+++ b/src/test/java/webserver/DispatcherServletTest.java
@@ -14,7 +14,6 @@ import static utils.StringUtils.appendNewLine;
 
 class DispatcherServletTest {
     private final String GET = "GET";
-    //    private final String PATH = "/user/create?userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net";
     private final String PATH = "/index.html";
 
     private final Uri URI = Uri.from(PATH);
@@ -30,18 +29,16 @@ class DispatcherServletTest {
                 "";
         in = new ByteArrayInputStream(requestStr.getBytes());
     }
-
-    @Test
-    @DisplayName("test")
-    void test() throws Throwable {
-        // given
-        HttpRequest request = HttpRequest.from(in);
-
-        //
-        Method method = HandlerMapping.getMethodMapped(request);
-        DispatcherServlet tmp = DispatcherServlet.init();
-
-        // then
-
-    }
+    
+//    @Test
+//    @DisplayName("컨텐츠 타입이 html인 경우, templates 폴더 안에서 파일을 가져온다")
+//    void doDispatchHtmlFile(){
+//        // given
+//
+//
+//        // when
+//
+//        // then
+//
+//    }
 }

--- a/src/test/java/webserver/HandlerMappingTest.java
+++ b/src/test/java/webserver/HandlerMappingTest.java
@@ -11,9 +11,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static utils.StringUtils.appendNewLine;
@@ -42,7 +39,7 @@ class HandlerMappingTest {
         HttpRequest request = HttpRequest.from(in);
 
         // then
-        HandlerMapping.getHandler(request);
+        HandlerMapping.getMethodMapped(request);
     }
 
     @Test
@@ -52,7 +49,7 @@ class HandlerMappingTest {
         HttpRequest request = HttpRequest.from(in);
 
         // when
-        Method method = HandlerMapping.getHandler(request);
+        Method method = HandlerMapping.getMethodMapped(request);
 
         // then
         assertEquals("createUser", method.getName());

--- a/src/test/java/webserver/HandlerMappingTest.java
+++ b/src/test/java/webserver/HandlerMappingTest.java
@@ -9,6 +9,7 @@ import webserver.http.request.Uri;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
@@ -54,4 +55,112 @@ class HandlerMappingTest {
         // then
         assertEquals("createUser", method.getName());
     }
+
+
+    class People {
+        public People(int money) {
+            this.money = money;
+        }
+
+        private int money;
+    }
+
+    @Test
+    @DisplayName("test")
+    void test() throws IllegalAccessException {
+
+
+        Class<People> clazz = People.class;
+        Field[] fields = clazz.getDeclaredFields();
+
+        People people = new People(1000);
+
+        fields[0].setAccessible(true);
+        System.out.println(fields[0]);
+    }
 }
+
+
+
+
+/*
+
+
+## 답안은 여기에다 작성
+
+## 기본
+
+### 1. autoboxing이란 무엇인가요?
+자바에서는 기본 primitive 타입에 대한 Wrapper class가 존재합니다. primitive 타입을 별도의 객체로 감쌌다고 해서 Wrapper class라 불리는데, primitive 타입에서 wrapper class로 감싸는 과정을 boxing, 반대의 과정을 unboxing 이라고 합니다. <br>
+즉 boxing, unboxing을 자바 자체적으로 자동으로 지원하는데 이를 autoboxing이라고 합니다.
+
+### 2. JVM의 메모리 구조에 대해 설명해 주세요.
+stack 영역, heap 영역, method 영역 등이 존재합니다. <br>
+stack 영역 => 메소드 호출에 대한 순서를 저장(콜스택), 지역 변수 저장 <br>
+heap 영역 => new 키워드를 통해서 할당하는 객체들은 heap 영역에 들어갑니다. 참고로 자바는 배열을 생성해 객체를 초기화 하기만 해도 모두 heap 영역에 들어가는 등, 메모리를 효율적으로 사용한다고는 할 수 없습니다. heap 영역에 할당된 객체들은 자기 자신을 가리키는 포인터가 없을 때 GC에 의해 수거됩니다. <br>
+method 영역 => 위에 설명한 부분 외에 여타 다른 것들은 대부분 method 영역에 들어가는 것으로 알고 있습니다.
+
+### 3. 자바 스레드의 동작 방식을 설명해 주세요.
+프로세스 내에서 여러 개의 스레드가 존재할 수 있습니다. 스레드란 실(thread)이라는 의미가 있는데 최소 작업 단위입니다.
+커널의 스레드와 JVM이 생성하는 스레드가 1:1로 매칭이 되어 동작합니다.
+
+### 4. protected와, default 접근한정자에 대해 설명해 주세요.
+같은 패키지 안에서만 접근할 수 있다는 공통점을 가지고 있습니다.
+차이점은 protected의 경우는 해당 클래스를 상속받으면 외부 패키지에서도 사용할 수 있게 되고 default는 그렇지 못합니다.
+따라서 접근을 한정하는 범위가 작은순으로 나열하면, private => default => protected => public 이라고 할 수 있습니다.
+
+## 람다, 스트림
+### 5. 자바 8에서 추가된 '람다식(Lambda Expressions)'는 무엇이며 왜 사용하나요?
+메소드가 하나만 존재하는 객체를 사용할 때, 별도로 선언을 하는 것이 아니라 바로 -> 키워드를 사용하여 메소드로써 동작하게 코드 작성이 가능합니다.
+
+### 6. 함수형 인터페이스는 무엇인가요
+자바스크립트 등 다른 언어에서는 함수를 일급 함수로 취급하는 경우가 있는데 자바는 그렇지 못합니다. 따라서 자바에서는 사전에 여러 함수형 인터페이스가 정의되어있습니다. 각 함수형 인터페이스에는 고유한 이름이 존재합니다.
+함수형 인터페이스는 정확히 하나의 추상메소드가 존재합니다.
+
+### 7. java.util.function에 있는 대표적인 함수형 인터페이스 4가지만 나열하고 간단히 설명해 주세요. <br>
+  7-1. Consumer => 인자 한개에 return 값이 존재하지 않습니다. <br>
+  7-2. Supplier => 인자가 존재하고 return 값도 존재합니다. (특별한 요구사항이 없습니다.) <br>
+  7-3. Function => 인자 한개에 return 값이 존재합니다. <br>
+  7-4. Predicate => boolean을 인자로 받아 타당한지 여부를 return 합니다. <br>
+
+
+### 8. 스트림이란 무엇이며 어떤 장점과 단점이 있나요?
+스트림은 loop을 돌 때 for 키워드를 사용하지 않고자 만들어졌습니다. stream 객체를 생성하고, 가공하고, 반환하는 3가지 구조로 나뉩니다. <br>
+스트림을 사용하면서 가독성이 좋아지고, 또 병렬 처리가 가능하도록 코드 작성이 가능합니다. 하지만 일반적으로 병렬 처리를 하지 않는 경우에 일반적으로 for 보다 성능이 더 좋지 않습니다. 따라서 항상 스트림이 좋은 것은 아니므로 경우에 맞게 사용해야 합니다.
+
+
+
+## 리플렉션, 어노테이션
+
+### 9. 리플렉션이란 무엇인가요? 장단점은?
+리플렉션은 클래스, 메소드, 필드 생성자의 정보를 런타임에 확인할 수 있는 기능입니다. java.lang.reflect 패키지 안에 있습니다. lang 패키지 안에 있기 때문에 사용하기 위해 별다른 패키지를 import 하지 않아도 됩니다. <br>
+장점은 리플렉션의 정의와 같이 런타임에 실행 정보를 확인할 수 있습니다. 자바만의 특징으로 C언어 등에서는 확인이 불가능합니다.
+단점으로는 리플렉션을 남용하면 부하가 생겨 성능의 지장을 줄 수 있습니다.
+
+
+### 10. People 클래스에 private int money가 있고 getter()가 없습니다. 리플렉션을 통해 값을 읽을 수 있나요? 있다면 코드를 작성해 주세요.
+값을 읽을 수 있습니다. 먼저 People class의 field 값을 setAccssible(true)를 통해 접근할 수 있게 만든 뒤에 원하는 값을 가져옵니다.
+
+''' <br>
+Class<People> clazz = People.class;
+Field[] fields = clazz.getDeclaredFields();
+
+People people = new People(1000);
+
+fields[0].setAccessible(true); <br>
+System.out.println(fields[0]); <br>
+'''
+
+### 11. 어노테이션이란 무엇입니까?
+클래스, 메소드, 필드 등에 붙일 수 있으며 어노테이션이 붙은 부분에 정해진 동작을 수행합니다. 어노테이션을 통해 중복 코드를 줄일 수 있으므로 AOP 실현을 돕습니다.
+
+
+### 12.자바의 기본 어노테이션 세가지에 대해 설명해 주세요.
+  12-1. @Override : 해당 메소드가 상위 클래스의 메소드를 상속하는지 여부를 알려줍니다. <br>
+  12-2. @Nullable : 해당 필드가 null 값을 갖을 수 있게 해줍니다. <br>
+  12-3. @Deprecated : 더이상 시용이 권장되지 않는 코드임을 알려줍니다. <br>
+
+### 13. 'Annotation'과 Reflection의 관계에 대해 설명해주세요.
+각 어노테이션마다 어느 기간까지 살아있을 수 있는지 스스로 결정합니다. 컴파일타임, 런타임 동안에도 살아있을 수 있는 어노테이션인 경우에 리플렉이션이 사용됩니다.
+
+ */


### PR DESCRIPTION
## 구현 내용
- 다양한 Content-Type 지원하도록 구현
  - [x] html
  - [x] css
  - [x] js
  - [x] ico
  - [x] png
  - [x] jpg
- [x] MIME 타입 이해하기

## 고민 사항
### 구조 리팩토링
step-3에서 구현해야하는 요구사항은 적었지만 지금까지 작성한 코드의 구조가 썩 마음에 들지 않았다. Dispatcher Servlet을 공부했다곤 하지만, 불완전하게 비슷한 흐름을 가져갔다. 
따라서 조금 코드가 난잡했는데 다음과 같이 수정했다. Controller 먼저 순회하고 매핑되는 요청이 없는 경우 static 파일을 가져오도록 수정하였다.

### 예외 처리
지난 step에서 잘못된 요청을 구분해 각각 다른 페이지를 보여주고 싶었으나 어려움을 겪었다. checked exception을 강제하는 메소드를 많이 사용해야했기 때문인데 실제 Dispatcher Servlet에서도 대부분의 메소드에 예외를 던지기 위해 throws 키워드를 사용하고 있었다. 이러한 한계점을 극복하고자 구분해야 할 필요성이 있는 함수에 exception 객체 자체를 메소드 인자로 넘겨서 추후에 processDispatcherResult()에서 처리해주었다. 괜찮은 방법이라 생각해서 차용하기로 했다.

### 갑자기 드는 의문
위에 적었듯이 비슷한 구조를 가져가고자 Dispatcher Servlet 코드를 이리저리 보았는데 다소 의아했다. 흐름 자체는 너무나도 깔끔하고 내 수준에서 봤을 때 잘짰다 싶었다. 하지만 메소드 안에 작성되어있는 코드 자체는 예쁘지가 않아 약간 실망(?)했다. 특정 로직 때문에 함수가 길어지는 경우에 “이 부분은 별도의 메소드로 분리를 해야될 거 같은데?” 라는 생각이 자주 들었다.
이런 생각이 드는 내가 좀 건방진가싶다.

### 컨텐츠 타입 구현
컨텐츠 타입에 여러 종류가 있기 때문에 분기 처리를 많이 해주어야 했다. Dispatcher Servlet 객체 혹은 HttpResponse가 분기 처리를 하느라 무차별적으로 길어져야만 했는데, 코드가 안예뻐져서 해당 책임을 ContentType이라는 객체에게 부여하면서 별도의 객체를 생성했다. 
클라이언트에서 들어온 요청의 path를 넘기기만 하면 어떤 ContentType 인지 스스로 결정하고 스스로 파일 경로를 추가하도록 했다.

## 기타
