### PR TITLE
[손승완] step-3 다양한 컨텐츠 타입 지원

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,21 @@
 # java-was-2023
 Java Web Application Server 2023
 
+# Step3
+## 미션 수행 목표
+- [ ] : HTTP Response 학습 및 위키 정리
+- [X] : MIME 타입 이해하고 적용하기 (서버의 static 폴더에 있는 정적 컨텐츠들에 대한 요청 정상 처리)
+
+## 미션 수행 기록
+- MIME 타입 관리하는 Enum 클래스 생성
+- Path에 대해서도 static 경로와 templates 경로를 관리하는 Enum 클래스 생성
+- requestUri 정보의 확장자를 파싱하고 해당 확장자에 알맞는 경로를 설정
+- 요청 파일에 알맞는 body와 header를 담아 응답하도록 처리
+
+## 변경 필요 사항
+- FrontController 부분에 대한 예외 처리 및 확장성 고려 필요
+- UserController 의 doGet 방식도 별로 좋진 않은 것 같다.
+- 테스트 코드 추가 해야한다! 
 
 # Step2
 ## 미션 수행 목표

--- a/src/main/java/utils/Parser.java
+++ b/src/main/java/utils/Parser.java
@@ -2,12 +2,12 @@ package utils;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import webserver.http.Path;
 
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
-import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -46,5 +46,18 @@ public class Parser {
             queryParams.put(param.substring(0, splitIndex), URLDecoder.decode(param.substring(splitIndex + 1), StandardCharsets.UTF_8));
         }
         return queryParams;
+    }
+
+    public static String parseExtension(String requestUri) {
+        String extension = requestUri.substring(requestUri.lastIndexOf(".") + 1);
+        return extension.toUpperCase();
+    }
+
+    public static String parsePath(String requestUri) {
+        String extension = parseExtension(requestUri);
+        if (extension.equals("HTML")) {
+            return Path.TEMPLATES.getPath() + requestUri;
+        }
+        return Path.STATIC.getPath() + requestUri;
     }
 }

--- a/src/main/java/webserver/http/HttpHeaders.java
+++ b/src/main/java/webserver/http/HttpHeaders.java
@@ -1,7 +1,5 @@
 package webserver.http;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import utils.Parser;
 
 import java.io.BufferedReader;

--- a/src/main/java/webserver/http/HttpHeaders.java
+++ b/src/main/java/webserver/http/HttpHeaders.java
@@ -1,5 +1,7 @@
 package webserver.http;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import utils.Parser;
 
 import java.io.BufferedReader;
@@ -10,10 +12,12 @@ import java.util.Map;
 import static utils.StringUtils.NEW_LINE;
 
 public class HttpHeaders {
-
     private final Map<String, String> headers;
     public HttpHeaders(Map<String, String> headers) {
         this.headers = headers;
+    }
+    public String getContentType() {
+        return headers.get("Content-Type");
     }
 
     public void show(StringBuilder sb) {
@@ -29,9 +33,10 @@ public class HttpHeaders {
         return new HttpHeaders(Parser.parseHeaders(br));
     }
 
-    public static HttpHeaders createStaticStatusHeaders(int bodyLength) {
+    public static HttpHeaders createStaticStatusHeaders(int bodyLength, String requestUri) {
         Map<String, String> responseHeaders = new HashMap<>();
-        responseHeaders.put("Content-Type", "text/html;charset=utf-8");
+        MIME mime = MIME.findMIME(requestUri);
+        responseHeaders.put("Content-Type", createStaticContentType(mime));
         responseHeaders.put("Content-Length", String.valueOf(bodyLength));
         return new HttpHeaders(responseHeaders);
     }
@@ -42,5 +47,9 @@ public class HttpHeaders {
         responseHeaders.put("Content-Length", "0");
         responseHeaders.put("Location", "http://localhost:8080/index.html");
         return new HttpHeaders(responseHeaders);
+    }
+
+    private static String createStaticContentType(MIME mime) {
+        return mime.getContentType() + ";charset=utf-8";
     }
 }

--- a/src/main/java/webserver/http/MIME.java
+++ b/src/main/java/webserver/http/MIME.java
@@ -1,0 +1,34 @@
+package webserver.http;
+
+import utils.Parser;
+
+import java.util.Arrays;
+
+public enum MIME {
+    CSS ("text/css"),
+    JS("text/javascript"),
+    ICO("image/x-icon"),
+    HTML("text/html"),
+    PNG("image/png"),
+    JPG("image/jpeg"),
+    TTF("font/ttf"),
+    WOFF("font/woff");
+
+    private final String contentType;
+
+    MIME(String contentType) {
+        this.contentType = contentType;
+    }
+
+    public String getContentType() {
+        return contentType;
+    }
+
+    public static MIME findMIME(String requestUri) {
+        String extension = Parser.parseExtension(requestUri);
+        return Arrays.stream(MIME.values())
+                .filter(mime -> mime.toString().equals(extension))
+                .findAny()
+                .orElseThrow(() -> new IllegalArgumentException("올바른 확장자가 아닙니다"));
+    }
+}

--- a/src/main/java/webserver/http/Path.java
+++ b/src/main/java/webserver/http/Path.java
@@ -1,0 +1,17 @@
+package webserver.http;
+
+public enum Path {
+    STATIC("src/main/resources/static"),
+    TEMPLATES("src/main/resources/templates");
+
+    private final String path;
+
+    Path(String path) {
+        this.path = path;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+}

--- a/src/main/java/webserver/http/response/HttpResponse.java
+++ b/src/main/java/webserver/http/response/HttpResponse.java
@@ -2,6 +2,7 @@ package webserver.http.response;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import utils.Parser;
 import webserver.http.HttpHeaders;
 
 import java.io.DataOutputStream;
@@ -33,7 +34,7 @@ public class HttpResponse {
     private void response200Header(DataOutputStream dos) {
         try {
             dos.writeBytes("HTTP/1.1 200 OK \r\n");
-            dos.writeBytes("Content-Type: text/html;charset=utf-8\r\n");
+            dos.writeBytes("Content-Type: " + httpHeaders.getContentType() +  "\r\n");
             dos.writeBytes("Content-Length: " + body.length + "\r\n");
             dos.writeBytes("\r\n");
         } catch (IOException e) {
@@ -63,10 +64,10 @@ public class HttpResponse {
     }
 
     public static HttpResponse createStatic(String requestUri) throws IOException {
-        byte[] body = Files.readAllBytes(new File("src/main/resources/templates" + requestUri).toPath());
+        byte[] body = Files.readAllBytes(new File(Parser.parsePath(requestUri)).toPath());
         return new HttpResponse(
                 HttpStatusLine.createStaticStatusLine(),
-                HttpHeaders.createStaticStatusHeaders(body.length),
+                HttpHeaders.createStaticStatusHeaders(body.length, requestUri),
                 body
         );
     }


### PR DESCRIPTION
## 구현 내용
- MIME 타입 관리하는 Enum 클래스 생성
- Path에 대해서도 static 경로와 templates 경로를 관리하는 Enum 클래스 생성
- requestUri 정보의 확장자를 파싱하고 해당 확장자에 알맞는 경로를 설정
- 요청 파일에 알맞는 body와 header를 담아 응답하도록 처리

## 고민 사항
- FrontController에 대한 예외 처리 및 확장성에 대해 고려할 필요가 있을 것 같다.
- UserController 역시 doGet 방식으로 처리했는데 이 방식 역시 확장성에 별로 좋지 않은 것 같다고 생각했다.
- 테스트 코드 추가 작성 필요!