### PR TITLE
[김동철] step-4 POST로 회원 가입

### DIFF
--- a/src/main/java/webserver/DispatcherServlet.java
+++ b/src/main/java/webserver/DispatcherServlet.java
@@ -2,12 +2,12 @@ package webserver;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import webserver.controller.FileController;
 import webserver.controller.UserSaveController;
 import webserver.http.HttpRequest;
 import webserver.http.HttpResponse;
-import webserver.utils.FileUtils;
-import webserver.utils.HttpField;
 import webserver.utils.HttpConstants;
+import webserver.utils.HttpField;
 import webserver.utils.HttpMethod;
 
 import java.io.BufferedInputStream;
@@ -36,7 +36,8 @@ public class DispatcherServlet implements Runnable {
                 UserSaveController userSaveController = new UserSaveController();
                 userSaveController.process(httpRequest, httpResponse);
             } else {
-                FileUtils.processFileResponse(httpRequest.get(HttpField.URI), httpResponse);
+                FileController fileController = new FileController();
+                fileController.process(httpRequest, httpResponse);
             }
 
             sendResponse(httpResponse, out);

--- a/src/main/java/webserver/DispatcherServlet.java
+++ b/src/main/java/webserver/DispatcherServlet.java
@@ -3,8 +3,9 @@ package webserver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import webserver.controller.UserSaveController;
-import webserver.http.HttpConstant;
-import webserver.utils.HttpMethodName;
+import webserver.utils.HttpConstants;
+import webserver.utils.HttpField;
+import webserver.utils.HttpMethod;
 import webserver.http.HttpRequest;
 import webserver.http.HttpResponse;
 import webserver.utils.FileUtils;
@@ -14,7 +15,6 @@ import java.net.Socket;
 
 public class DispatcherServlet implements Runnable {
     private static final Logger logger = LoggerFactory.getLogger(DispatcherServlet.class);
-
     private final Socket connection;
 
     public DispatcherServlet(Socket connectionSocket) {
@@ -31,7 +31,7 @@ public class DispatcherServlet implements Runnable {
             HttpRequest httpRequest = new HttpRequest(in);
             HttpResponse httpResponse = new HttpResponse();
 
-            if (httpRequest.get(HttpConstant.METHOD).equals(HttpMethodName.GET) && httpRequest.getPath().equals("/user/create")) {
+            if (httpRequest.get(HttpField.METHOD).equals(HttpMethod.GET) && httpRequest.getPath().equals("/user/create")) {
                 UserSaveController userSaveController = new UserSaveController();
                 userSaveController.process(httpRequest, httpResponse);
             } else {
@@ -65,7 +65,7 @@ public class DispatcherServlet implements Runnable {
         BufferedOutputStream bufferedOutputStream = new BufferedOutputStream(out);
 
         bufferedOutputStream.write(httpResponse.getHeaderBytes());
-        bufferedOutputStream.write(HttpConstant.CRLF.getBytes());
+        bufferedOutputStream.write(HttpConstants.CRLF.getBytes());
         if (!httpResponse.isBodyEmpty()) {
             bufferedOutputStream.write(httpResponse.getBodyBytes());
         }

--- a/src/main/java/webserver/DispatcherServlet.java
+++ b/src/main/java/webserver/DispatcherServlet.java
@@ -4,7 +4,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import webserver.controller.UserSaveController;
 import webserver.http.HttpConstant;
-import webserver.http.HttpMethod;
+import webserver.utils.HttpMethodName;
 import webserver.http.HttpRequest;
 import webserver.http.HttpResponse;
 import webserver.utils.FileUtils;
@@ -31,7 +31,7 @@ public class DispatcherServlet implements Runnable {
             HttpRequest httpRequest = new HttpRequest(in);
             HttpResponse httpResponse = new HttpResponse();
 
-            if (httpRequest.get(HttpConstant.METHOD).equals(HttpMethod.GET.toString()) && httpRequest.getPath().equals("/user/create")) {
+            if (httpRequest.get(HttpConstant.METHOD).equals(HttpMethodName.GET) && httpRequest.getPath().equals("/user/create")) {
                 UserSaveController userSaveController = new UserSaveController();
                 userSaveController.process(httpRequest, httpResponse);
             } else {

--- a/src/main/java/webserver/DispatcherServlet.java
+++ b/src/main/java/webserver/DispatcherServlet.java
@@ -3,14 +3,17 @@ package webserver;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import webserver.controller.UserSaveController;
-import webserver.utils.HttpConstants;
-import webserver.utils.HttpField;
-import webserver.utils.HttpMethod;
 import webserver.http.HttpRequest;
 import webserver.http.HttpResponse;
 import webserver.utils.FileUtils;
+import webserver.utils.HttpConstants;
+import webserver.utils.HttpField;
+import webserver.utils.HttpMethod;
 
-import java.io.*;
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
 import java.net.Socket;
 
 public class DispatcherServlet implements Runnable {
@@ -29,11 +32,11 @@ public class DispatcherServlet implements Runnable {
             HttpRequest httpRequest = new HttpRequest(in);
             HttpResponse httpResponse = new HttpResponse();
 
-            if (httpRequest.get(HttpField.METHOD).equals(HttpMethod.GET) && httpRequest.getPath().equals("/user/create")) {
+            if (httpRequest.get(HttpField.METHOD).equals(HttpMethod.GET) && httpRequest.get(HttpField.PATH).equals("/user/create")) {
                 UserSaveController userSaveController = new UserSaveController();
                 userSaveController.process(httpRequest, httpResponse);
             } else {
-                FileUtils.processFileResponse(httpRequest.getURI(), httpResponse);
+                FileUtils.processFileResponse(httpRequest.get(HttpField.URI), httpResponse);
             }
 
             sendResponse(httpResponse, out);

--- a/src/main/java/webserver/DispatcherServlet.java
+++ b/src/main/java/webserver/DispatcherServlet.java
@@ -32,7 +32,7 @@ public class DispatcherServlet implements Runnable {
             HttpRequest httpRequest = new HttpRequest(in);
             HttpResponse httpResponse = new HttpResponse();
 
-            if (httpRequest.get(HttpField.METHOD).equals(HttpMethod.GET) && httpRequest.get(HttpField.PATH).equals("/user/create")) {
+            if (httpRequest.get(HttpField.METHOD).equals(HttpMethod.POST) && httpRequest.get(HttpField.PATH).equals("/user/create")) {
                 UserSaveController userSaveController = new UserSaveController();
                 userSaveController.process(httpRequest, httpResponse);
             } else {

--- a/src/main/java/webserver/DispatcherServlet.java
+++ b/src/main/java/webserver/DispatcherServlet.java
@@ -6,8 +6,8 @@ import webserver.controller.UserSaveController;
 import webserver.http.HttpRequest;
 import webserver.http.HttpResponse;
 import webserver.utils.FileUtils;
-import webserver.utils.HttpConstants;
 import webserver.utils.HttpField;
+import webserver.utils.HttpConstants;
 import webserver.utils.HttpMethod;
 
 import java.io.BufferedInputStream;

--- a/src/main/java/webserver/DispatcherServlet.java
+++ b/src/main/java/webserver/DispatcherServlet.java
@@ -26,8 +26,6 @@ public class DispatcherServlet implements Runnable {
                 connection.getPort());
 
         try (BufferedInputStream in = new BufferedInputStream(connection.getInputStream()); OutputStream out = connection.getOutputStream()) {
-            logRequestMessageAndResetStream(in);
-
             HttpRequest httpRequest = new HttpRequest(in);
             HttpResponse httpResponse = new HttpResponse();
 
@@ -42,23 +40,6 @@ public class DispatcherServlet implements Runnable {
         } catch (IOException e) {
             logger.error(e.getMessage());
         }
-    }
-
-    private void logRequestMessageAndResetStream(BufferedInputStream in) throws IOException {
-        StringBuilder stringBuilder = new StringBuilder();
-        BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(in));
-        String line;
-
-        in.mark(0);
-
-        while (bufferedReader.ready()) {
-            line = bufferedReader.readLine();
-            stringBuilder.append(line).append('\n');
-        }
-
-        in.reset();
-
-        logger.debug("{}", stringBuilder);
     }
 
     private void sendResponse(HttpResponse httpResponse, OutputStream out) throws IOException {

--- a/src/main/java/webserver/controller/FileController.java
+++ b/src/main/java/webserver/controller/FileController.java
@@ -1,0 +1,34 @@
+package webserver.controller;
+
+import webserver.http.HttpRequest;
+import webserver.http.HttpResponse;
+import webserver.http.HttpStatus;
+import webserver.utils.ContentTypeResolver;
+import webserver.utils.FileUtils;
+import webserver.utils.HttpField;
+
+import java.io.IOException;
+
+public class FileController {
+    public void process(HttpRequest httpRequest, HttpResponse httpResponse) throws IOException {
+        String filePath = httpRequest.get(HttpField.PATH);
+
+        filePath = FileUtils.preprocessFilePath(filePath);
+
+        byte[] body = FileUtils.readFile(filePath);
+        HttpStatus status = resolveHttpStatus(filePath);
+        String contentType = ContentTypeResolver.getContentType(filePath);
+
+        httpResponse.setStatus(status);
+        httpResponse.set(HttpField.CONTENT_TYPE, contentType);
+        httpResponse.set(HttpField.CONTENT_LENGTH, body.length);
+        httpResponse.setBody(body);
+    }
+
+    private static HttpStatus resolveHttpStatus(String path) {
+        if (path.equals("/404.html")) {
+            return HttpStatus.NOT_FOUND;
+        }
+        return HttpStatus.OK;
+    }
+}

--- a/src/main/java/webserver/controller/UserSaveController.java
+++ b/src/main/java/webserver/controller/UserSaveController.java
@@ -4,16 +4,15 @@ import db.Database;
 import model.User;
 import webserver.exceptions.BadRequestException;
 import webserver.exceptions.ConflictException;
+import webserver.http.HttpParameters;
 import webserver.http.HttpRequest;
 import webserver.http.HttpResponse;
 import webserver.http.HttpStatus;
 
-import java.util.Map;
-
 public class UserSaveController {
     public void process(HttpRequest httpRequest, HttpResponse httpResponse) {
         try {
-            Map<String, String> parametersMap = httpRequest.getParametersMap();
+            HttpParameters parametersMap = httpRequest.getParameters();
 
             verifyParametersCount(parametersMap);
 
@@ -40,7 +39,7 @@ public class UserSaveController {
         }
     }
 
-    private void verifyParametersCount(Map<String, String> parametersMap) throws BadRequestException {
+    private void verifyParametersCount(HttpParameters parametersMap) throws BadRequestException {
         if (parametersMap.size() != 4) {
             throw new BadRequestException();
         }

--- a/src/main/java/webserver/controller/UserSaveController.java
+++ b/src/main/java/webserver/controller/UserSaveController.java
@@ -34,9 +34,6 @@ public class UserSaveController {
             httpResponse.setStatus(HttpStatus.BAD_REQUEST);
         } catch (ConflictException e) {
             httpResponse.setStatus(HttpStatus.CONFLICT);
-        } finally {
-            httpResponse.setContentType("application/json");
-            httpResponse.setContentLength(0);
         }
     }
 

--- a/src/main/java/webserver/controller/UserSaveController.java
+++ b/src/main/java/webserver/controller/UserSaveController.java
@@ -8,11 +8,12 @@ import webserver.http.HttpParameters;
 import webserver.http.HttpRequest;
 import webserver.http.HttpResponse;
 import webserver.http.HttpStatus;
+import webserver.utils.HttpParametersParser;
 
 public class UserSaveController {
     public void process(HttpRequest httpRequest, HttpResponse httpResponse) {
         try {
-            HttpParameters httpParameters = httpRequest.getParameters();
+            HttpParameters httpParameters = HttpParametersParser.parse(httpRequest.getBody());
 
             verifyParametersCount(httpParameters);
 

--- a/src/main/java/webserver/controller/UserSaveController.java
+++ b/src/main/java/webserver/controller/UserSaveController.java
@@ -12,18 +12,18 @@ import webserver.http.HttpStatus;
 public class UserSaveController {
     public void process(HttpRequest httpRequest, HttpResponse httpResponse) {
         try {
-            HttpParameters parametersMap = httpRequest.getParameters();
+            HttpParameters httpParameters = httpRequest.getParameters();
 
-            verifyParametersCount(parametersMap);
+            verifyParametersCount(httpParameters);
 
-            String userId = (String) parametersMap.get("userId");
-            String password = (String) parametersMap.get("password");
-            String name = (String) parametersMap.get("name");
-            String email = (String) parametersMap.get("email");
+            String userId = httpParameters.get("userId");
+            String password = httpParameters.get("password");
+            String name = httpParameters.get("name");
+            String email =  httpParameters.get("email");
 
             verifyEmptyParameter(userId, password, name, email);
 
-            verifyUserIdConflict(userId);
+            verifyUserIdAvailable(userId);
 
             User user = new User(userId, password, name, email);
             Database.addUser(user);
@@ -39,8 +39,8 @@ public class UserSaveController {
         }
     }
 
-    private void verifyParametersCount(HttpParameters parametersMap) throws BadRequestException {
-        if (parametersMap.size() != 4) {
+    private void verifyParametersCount(HttpParameters httpParameters) throws BadRequestException {
+        if (httpParameters.size() != 4) {
             throw new BadRequestException();
         }
     }
@@ -51,7 +51,7 @@ public class UserSaveController {
         }
     }
 
-    private void verifyUserIdConflict(String userId) throws ConflictException {
+    private void verifyUserIdAvailable(String userId) throws ConflictException {
         if (Database.findUserById(userId) != null) {
             throw new ConflictException();
         }

--- a/src/main/java/webserver/controller/UserSaveController.java
+++ b/src/main/java/webserver/controller/UserSaveController.java
@@ -8,6 +8,7 @@ import webserver.http.HttpParameters;
 import webserver.http.HttpRequest;
 import webserver.http.HttpResponse;
 import webserver.http.HttpStatus;
+import webserver.utils.HttpField;
 import webserver.utils.HttpParametersParser;
 
 public class UserSaveController {
@@ -29,7 +30,8 @@ public class UserSaveController {
             User user = new User(userId, password, name, email);
             Database.addUser(user);
 
-            httpResponse.setStatus(HttpStatus.OK);
+            httpResponse.setStatus(HttpStatus.FOUND);
+            httpResponse.set(HttpField.LOCATION, "/index.html");
         } catch (BadRequestException e) {
             httpResponse.setStatus(HttpStatus.BAD_REQUEST);
         } catch (ConflictException e) {

--- a/src/main/java/webserver/http/HttpHeaders.java
+++ b/src/main/java/webserver/http/HttpHeaders.java
@@ -1,0 +1,21 @@
+package webserver.http;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class HttpHeaders {
+    private final Map<String, String> headers;
+
+    public HttpHeaders() {
+        this.headers = new HashMap<>();
+    }
+
+    public String get(String field) {
+        return new String(headers.get(field));
+    }
+
+    public void put(String field, String value) {
+        headers.put(field, value);
+    }
+
+}

--- a/src/main/java/webserver/http/HttpHeaders.java
+++ b/src/main/java/webserver/http/HttpHeaders.java
@@ -10,12 +10,15 @@ public class HttpHeaders {
         this.headers = new HashMap<>();
     }
 
-    public String get(String field) {
-        return new String(headers.get(field));
+    public String get(String name) {
+        if (headers.containsKey(name)) {
+            return new String(headers.get(name));
+        }
+        return null;
     }
 
-    public void put(String field, String value) {
-        headers.put(field, value);
+    public void put(String name, String value) {
+        headers.put(name, value);
     }
 
 }

--- a/src/main/java/webserver/http/HttpHeaders.java
+++ b/src/main/java/webserver/http/HttpHeaders.java
@@ -2,6 +2,7 @@ package webserver.http;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 public class HttpHeaders {
     private final Map<String, String> headers;
@@ -21,4 +22,7 @@ public class HttpHeaders {
         headers.put(name, value);
     }
 
+    public Set<String> getFieldNames() {
+        return headers.keySet();
+    }
 }

--- a/src/main/java/webserver/http/HttpMethod.java
+++ b/src/main/java/webserver/http/HttpMethod.java
@@ -1,5 +1,0 @@
-package webserver.http;
-
-public enum HttpMethod {
-    GET, PUT, POST, DELETE;
-}

--- a/src/main/java/webserver/http/HttpParameters.java
+++ b/src/main/java/webserver/http/HttpParameters.java
@@ -1,0 +1,24 @@
+package webserver.http;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class HttpParameters {
+    private final Map<String, String> parameters;
+
+    public HttpParameters() {
+        parameters = new HashMap<>();
+    }
+
+    public String get(String name) {
+        return new String(parameters.get(name));
+    }
+
+    public void put(String name, String value) {
+        parameters.put(name, value);
+    }
+
+    public int size() {
+        return parameters.size();
+    }
+}

--- a/src/main/java/webserver/http/HttpRequest.java
+++ b/src/main/java/webserver/http/HttpRequest.java
@@ -27,7 +27,7 @@ public class HttpRequest {
         parseRequestMessage();
     }
 
-    public void parseRequestMessage() throws IOException {
+    private void parseRequestMessage() throws IOException {
         parseHeader();
         parseBody();
     }

--- a/src/main/java/webserver/http/HttpRequest.java
+++ b/src/main/java/webserver/http/HttpRequest.java
@@ -1,6 +1,7 @@
 package webserver.http;
 
 import webserver.utils.HttpField;
+import webserver.utils.HttpParametersParser;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -13,7 +14,7 @@ public class HttpRequest {
     private final BufferedReader bufferedReader;
 
     private final HttpHeaders httpHeaders;
-    private final HttpParameters httpParameters;
+    private HttpParameters httpParameters;
     private String body = "";
 
 
@@ -52,17 +53,7 @@ public class HttpRequest {
         httpHeaders.put(HttpField.PATH, uriTokens[0]);
 
         if (uriTokens.length == 2) {
-            parseParameters(uriTokens[1]);
-        }
-    }
-
-    private void parseParameters(String parameters) {
-        for (String parameter : parameters.split("&")) {
-            String[] tokens = parameter.split("=");
-
-            if (tokens.length == 2) {
-                httpParameters.put(tokens[0], tokens[1]);
-            }
+            httpParameters = HttpParametersParser.parse(uriTokens[1]);
         }
     }
 

--- a/src/main/java/webserver/http/HttpRequest.java
+++ b/src/main/java/webserver/http/HttpRequest.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.StringTokenizer;
 import java.util.stream.Collectors;
 
@@ -44,7 +45,7 @@ public class HttpRequest {
         StringTokenizer stringTokenizer = new StringTokenizer(requestLine);
 
         httpHeaders.put(HttpField.METHOD, stringTokenizer.nextToken());
-        httpHeaders.put(HttpField.URI, URLDecoder.decode(stringTokenizer.nextToken()));
+        httpHeaders.put(HttpField.URI, URLDecoder.decode(stringTokenizer.nextToken(), StandardCharsets.UTF_8));
         httpHeaders.put(HttpField.VERSION, stringTokenizer.nextToken());
 
         parsePathAndParameters(httpHeaders.get(HttpField.URI));

--- a/src/main/java/webserver/http/HttpRequest.java
+++ b/src/main/java/webserver/http/HttpRequest.java
@@ -1,5 +1,8 @@
 package webserver.http;
 
+import webserver.utils.HttpConstants;
+import webserver.utils.HttpField;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
@@ -40,11 +43,11 @@ public class HttpRequest {
         String requestLine = bufferedReader.readLine();
         StringTokenizer stringTokenizer = new StringTokenizer(requestLine);
 
-        httpHeaders.put(HttpConstant.METHOD, stringTokenizer.nextToken());
-        httpHeaders.put(HttpConstant.URI, URLDecoder.decode(stringTokenizer.nextToken()));
-        httpHeaders.put(HttpConstant.VERSION, stringTokenizer.nextToken());
+        httpHeaders.put(HttpField.METHOD, stringTokenizer.nextToken());
+        httpHeaders.put(HttpField.URI, URLDecoder.decode(stringTokenizer.nextToken()));
+        httpHeaders.put(HttpField.VERSION, stringTokenizer.nextToken());
 
-        parsePathAndParameters(httpHeaders.get(HttpConstant.URI));
+        parsePathAndParameters(httpHeaders.get(HttpField.URI));
     }
 
     private void parsePathAndParameters(String URI) {
@@ -81,7 +84,7 @@ public class HttpRequest {
 
     private void parseBody(BufferedReader bufferedReader) throws IOException {
         if (bufferedReader.ready()) {
-            String body = bufferedReader.lines().collect(Collectors.joining(HttpConstant.CRLF));
+            String body = bufferedReader.lines().collect(Collectors.joining(HttpConstants.CRLF));
             httpHeaders.put("body", body);
             return;
         }
@@ -97,7 +100,7 @@ public class HttpRequest {
     }
 
     public String getURI() {
-        return httpHeaders.get(HttpConstant.URI);
+        return httpHeaders.get(HttpField.URI);
     }
 
     public String getPath() {

--- a/src/main/java/webserver/http/HttpRequest.java
+++ b/src/main/java/webserver/http/HttpRequest.java
@@ -5,19 +5,17 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.net.URLDecoder;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.StringTokenizer;
 import java.util.stream.Collectors;
 
 public class HttpRequest {
-    private final Map<String, String> headers;
+    private final HttpHeaders httpHeaders;
+    private final HttpParameters httpParameters;
     private String path;
-    private final Map<String, String> parametersMap;
 
     public HttpRequest(InputStream in) throws IOException {
-        headers = new HashMap<>();
-        parametersMap = new HashMap<>();
+        httpHeaders = new HttpHeaders();
+        httpParameters = new HttpParameters();
 
         parseRequestMessage(in);
     }
@@ -42,11 +40,11 @@ public class HttpRequest {
         String requestLine = bufferedReader.readLine();
         StringTokenizer stringTokenizer = new StringTokenizer(requestLine);
 
-        headers.put(HttpConstant.METHOD, stringTokenizer.nextToken());
-        headers.put(HttpConstant.URI, URLDecoder.decode(stringTokenizer.nextToken()));
-        headers.put(HttpConstant.VERSION, stringTokenizer.nextToken());
+        httpHeaders.put(HttpConstant.METHOD, stringTokenizer.nextToken());
+        httpHeaders.put(HttpConstant.URI, URLDecoder.decode(stringTokenizer.nextToken()));
+        httpHeaders.put(HttpConstant.VERSION, stringTokenizer.nextToken());
 
-        parsePathAndParameters(headers.get(HttpConstant.URI));
+        parsePathAndParameters(httpHeaders.get(HttpConstant.URI));
     }
 
     private void parsePathAndParameters(String URI) {
@@ -67,7 +65,7 @@ public class HttpRequest {
             separatorIndex = parameter.indexOf("=");
             String name = parameter.substring(0, separatorIndex);
             String value = parameter.substring(separatorIndex + 1);
-            parametersMap.put(name, value);
+            httpParameters.put(name, value);
         }
     }
 
@@ -77,36 +75,36 @@ public class HttpRequest {
             int colonIndex = line.indexOf(":");
             String field = line.substring(0, colonIndex);
             String value = line.substring(colonIndex + 1).trim();
-            headers.put(field, value);
+            httpHeaders.put(field, value);
         }
     }
 
     private void parseBody(BufferedReader bufferedReader) throws IOException {
         if (bufferedReader.ready()) {
             String body = bufferedReader.lines().collect(Collectors.joining(HttpConstant.CRLF));
-            headers.put("body", body);
+            httpHeaders.put("body", body);
             return;
         }
-        headers.put("body", "");
+        httpHeaders.put("body", "");
     }
 
     public String get(String fieldName) {
-        return headers.get(fieldName);
+        return httpHeaders.get(fieldName);
     }
 
     public String getBody() {
-        return headers.get("body");
+        return httpHeaders.get("body");
     }
 
     public String getURI() {
-        return headers.get(HttpConstant.URI);
+        return httpHeaders.get(HttpConstant.URI);
     }
 
     public String getPath() {
         return path;
     }
 
-    public Map<String, String> getParametersMap() {
-        return parametersMap;
+    public HttpParameters getParameters() {
+        return httpParameters;
     }
 }

--- a/src/main/java/webserver/http/HttpResponse.java
+++ b/src/main/java/webserver/http/HttpResponse.java
@@ -1,34 +1,34 @@
 package webserver.http;
 
 import webserver.utils.HttpConstants;
-import webserver.utils.HttpField;
-
-import java.util.LinkedHashMap;
-import java.util.Map;
 
 public class HttpResponse {
     private HttpStatus status;
-    private final Map<String, String> headers;
+    private final HttpHeaders headers;
     private byte[] body;
 
     public HttpResponse() {
-        headers = new LinkedHashMap<>();
+        headers = new HttpHeaders();
     }
 
-    public void setHeader(String name, String value) {
+    public String get(String name) {
+        return headers.get(name);
+    }
+
+    public void set(String name, String value) {
         headers.put(name, value);
+    }
+
+    public void set(String name, int value) {
+        headers.put(name, String.valueOf(value));
+    }
+
+    public HttpStatus getStatus() {
+        return status;
     }
 
     public void setStatus(HttpStatus status) {
         this.status = status;
-    }
-
-    public void setContentType(String contentType) {
-        headers.put(HttpField.CONTENT_TYPE, contentType);
-    }
-
-    public void setContentLength(int contentLength) {
-        headers.put(HttpField.CONTENT_LENGTH, String.valueOf(contentLength));
     }
 
     public void setBody(byte[] body) {
@@ -42,21 +42,16 @@ public class HttpResponse {
     public String getHeaderMessage() {
         StringBuilder stringBuilder = new StringBuilder();
 
-        stringBuilder.append(status.getStatusLine())
-                .append(HttpConstants.CRLF);
+        stringBuilder.append(status.getStatusLine()).append(HttpConstants.CRLF);
 
-        for (String key : headers.keySet()) {
-            stringBuilder.append(key)
+        for (String fieldName : headers.getFieldNames()) {
+            stringBuilder.append(fieldName)
                     .append(": ")
-                    .append(headers.get(key))
+                    .append(headers.get(fieldName))
                     .append(HttpConstants.CRLF);
         }
 
         return stringBuilder.toString();
-    }
-
-    public HttpStatus getStatus() {
-        return status;
     }
 
     public byte[] getHeaderBytes() {

--- a/src/main/java/webserver/http/HttpResponse.java
+++ b/src/main/java/webserver/http/HttpResponse.java
@@ -1,5 +1,8 @@
 package webserver.http;
 
+import webserver.utils.HttpConstants;
+import webserver.utils.HttpField;
+
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -21,11 +24,11 @@ public class HttpResponse {
     }
 
     public void setContentType(String contentType) {
-        headers.put(HttpConstant.CONTENT_TYPE, contentType);
+        headers.put(HttpField.CONTENT_TYPE, contentType);
     }
 
     public void setContentLength(int contentLength) {
-        headers.put(HttpConstant.CONTENT_LENGTH, String.valueOf(contentLength));
+        headers.put(HttpField.CONTENT_LENGTH, String.valueOf(contentLength));
     }
 
     public void setBody(byte[] body) {
@@ -40,13 +43,13 @@ public class HttpResponse {
         StringBuilder stringBuilder = new StringBuilder();
 
         stringBuilder.append(status.getStatusLine())
-                .append(HttpConstant.CRLF);
+                .append(HttpConstants.CRLF);
 
         for (String key : headers.keySet()) {
             stringBuilder.append(key)
                     .append(": ")
                     .append(headers.get(key))
-                    .append(HttpConstant.CRLF);
+                    .append(HttpConstants.CRLF);
         }
 
         return stringBuilder.toString();

--- a/src/main/java/webserver/utils/FileUtils.java
+++ b/src/main/java/webserver/utils/FileUtils.java
@@ -22,16 +22,16 @@ public final class FileUtils {
         String contentType = ContentTypeResolver.getContentType(URI);
 
         httpResponse.setStatus(status);
-        httpResponse.setContentType(contentType);
-        httpResponse.setContentLength(body.length);
+        httpResponse.set(HttpField.CONTENT_TYPE, contentType);
+        httpResponse.set(HttpField.CONTENT_LENGTH, body.length);
         httpResponse.setBody(body);
     }
 
     private static String preprocessURI(String URI) {
-        if(isFileExist(URI)) {
+        if (isFileExist(URI)) {
             return URI;
         }
-        if(URI.equals("/")) {
+        if (URI.equals("/")) {
             return "/index.html";
         }
         return "/404.html";
@@ -45,7 +45,7 @@ public final class FileUtils {
     }
 
     private static HttpStatus resolveHttpStatus(String URI) {
-        if(URI.equals("/404.html")) {
+        if (URI.equals("/404.html")) {
             return HttpStatus.NOT_FOUND;
         }
         return HttpStatus.OK;

--- a/src/main/java/webserver/utils/FileUtils.java
+++ b/src/main/java/webserver/utils/FileUtils.java
@@ -1,8 +1,5 @@
 package webserver.utils;
 
-import webserver.http.HttpResponse;
-import webserver.http.HttpStatus;
-
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -15,40 +12,21 @@ public final class FileUtils {
     private FileUtils() {
     }
 
-    public static void processFileResponse(String URI, HttpResponse httpResponse) throws IOException {
-        URI = preprocessURI(URI);
-        byte[] body = readFileBytes(URI);
-        HttpStatus status = resolveHttpStatus(URI);
-        String contentType = ContentTypeResolver.getContentType(URI);
-
-        httpResponse.setStatus(status);
-        httpResponse.set(HttpField.CONTENT_TYPE, contentType);
-        httpResponse.set(HttpField.CONTENT_LENGTH, body.length);
-        httpResponse.setBody(body);
+    public static byte[] readFile(String path) throws IOException {
+        if (FileUtils.isStaticFile(path)) {
+            return Files.readAllBytes(Paths.get(STATIC_DIRECTORY + path));
+        }
+        return Files.readAllBytes(Paths.get(TEMPLATES_DIRECTORY + path));
     }
 
-    private static String preprocessURI(String URI) {
-        if (isFileExist(URI)) {
-            return URI;
+    public static String preprocessFilePath(String path) {
+        if (isFileExist(path)) {
+            return path;
         }
-        if (URI.equals("/")) {
+        if (path.equals("/")) {
             return "/index.html";
         }
         return "/404.html";
-    }
-
-    public static byte[] readFileBytes(String URI) throws IOException {
-        if (FileUtils.isStaticFile(URI)) {
-            return Files.readAllBytes(Paths.get(STATIC_DIRECTORY + URI));
-        }
-        return Files.readAllBytes(Paths.get(TEMPLATES_DIRECTORY + URI));
-    }
-
-    private static HttpStatus resolveHttpStatus(String URI) {
-        if (URI.equals("/404.html")) {
-            return HttpStatus.NOT_FOUND;
-        }
-        return HttpStatus.OK;
     }
 
     private static boolean isFileExist(String URI) {

--- a/src/main/java/webserver/utils/HttpConstants.java
+++ b/src/main/java/webserver/utils/HttpConstants.java
@@ -1,0 +1,7 @@
+package webserver.utils;
+
+public class HttpConstants {
+    public static final String CRLF = "\r\n";
+
+    private HttpConstants() {}
+}

--- a/src/main/java/webserver/utils/HttpField.java
+++ b/src/main/java/webserver/utils/HttpField.java
@@ -8,6 +8,8 @@ public final class HttpField {
     public static final String CONTENT_TYPE = "Content-Type";
     public static final String CONTENT_LENGTH = "Content-Length";
     public static final String AUTHORIZATION = "Authorization";
+    public static final String PATH = "Path";
 
-    private HttpField() {}
+    private HttpField() {
+    }
 }

--- a/src/main/java/webserver/utils/HttpField.java
+++ b/src/main/java/webserver/utils/HttpField.java
@@ -9,6 +9,7 @@ public final class HttpField {
     public static final String CONTENT_LENGTH = "Content-Length";
     public static final String AUTHORIZATION = "Authorization";
     public static final String PATH = "Path";
+    public static final String LOCATION = "Location";
 
     private HttpField() {
     }

--- a/src/main/java/webserver/utils/HttpField.java
+++ b/src/main/java/webserver/utils/HttpField.java
@@ -1,14 +1,13 @@
-package webserver.http;
+package webserver.utils;
 
-public final class HttpConstant {
+public final class HttpField {
 
     public static final String METHOD = "Method";
     public static final String URI = "URI";
     public static final String VERSION = "Version";
-    public static final String CRLF = "\r\n";
     public static final String CONTENT_TYPE = "Content-Type";
     public static final String CONTENT_LENGTH = "Content-Length";
     public static final String AUTHORIZATION = "Authorization";
 
-    private HttpConstant() {}
+    private HttpField() {}
 }

--- a/src/main/java/webserver/utils/HttpMethod.java
+++ b/src/main/java/webserver/utils/HttpMethod.java
@@ -2,7 +2,7 @@ package webserver.utils;
 
 public final class HttpMethod {
     public static final String GET = "GET";
-    public static final String POST = "POSt";
+    public static final String POST = "POST";
     public static final String PUT = "PUT";
     public static final String DELETE = "DELETE";
 

--- a/src/main/java/webserver/utils/HttpMethod.java
+++ b/src/main/java/webserver/utils/HttpMethod.java
@@ -1,10 +1,10 @@
 package webserver.utils;
 
-public final class HttpMethodName {
+public final class HttpMethod {
     public static final String GET = "GET";
     public static final String POST = "POSt";
     public static final String PUT = "PUT";
     public static final String DELETE = "DELETE";
 
-    private HttpMethodName() {}
+    private HttpMethod() {}
 }

--- a/src/main/java/webserver/utils/HttpMethodName.java
+++ b/src/main/java/webserver/utils/HttpMethodName.java
@@ -1,0 +1,10 @@
+package webserver.utils;
+
+public final class HttpMethodName {
+    public static final String GET = "GET";
+    public static final String POST = "POSt";
+    public static final String PUT = "PUT";
+    public static final String DELETE = "DELETE";
+
+    private HttpMethodName() {}
+}

--- a/src/main/java/webserver/utils/HttpParametersParser.java
+++ b/src/main/java/webserver/utils/HttpParametersParser.java
@@ -1,0 +1,30 @@
+package webserver.utils;
+
+import webserver.http.HttpParameters;
+
+public final class HttpParametersParser {
+    private HttpParametersParser() {
+    }
+
+    public static HttpParameters parse(String parameters) {
+        HttpParameters httpParameters = new HttpParameters();
+
+        if (parameters == null || parameters.isEmpty()) {
+            return httpParameters;
+        }
+
+        for (String parameter : parameters.split("&")) {
+            if (parameter.isEmpty()) {
+                continue;
+            }
+
+            String[] tokens = parameter.split("=");
+
+            if (tokens.length == 2) {
+                httpParameters.put(tokens[0], tokens[1]);
+            }
+        }
+
+        return httpParameters;
+    }
+}

--- a/src/main/resources/templates/user/form.html
+++ b/src/main/resources/templates/user/form.html
@@ -75,7 +75,7 @@
 <div class="container" id="main">
    <div class="col-md-6 col-md-offset-3">
       <div class="panel panel-default content-main">
-          <form name="question" method="get" action="/user/create">
+          <form name="question" method="post" action="/user/create">
               <div class="form-group">
                   <label for="userId">사용자 아이디</label>
                   <input class="form-control" id="userId" name="userId" placeholder="User ID">

--- a/src/test/java/webserver/controller/FileControllerTest.java
+++ b/src/test/java/webserver/controller/FileControllerTest.java
@@ -1,0 +1,109 @@
+package webserver.controller;
+
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import webserver.http.HttpRequest;
+import webserver.http.HttpResponse;
+import webserver.http.HttpStatus;
+import webserver.utils.HttpField;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+class FileControllerTest {
+    FileController fileController = new FileController();
+
+    SoftAssertions softAssertions;
+    HttpRequest httpRequest;
+    HttpResponse httpResponse;
+
+
+    @BeforeEach
+    void init() {
+        softAssertions = new SoftAssertions();
+    }
+
+    @Test
+    @DisplayName("Request-URI가 '/'인 경우, /index.html 페이지를 응답한다")
+    void getWithoutPath() throws Exception {
+        //given
+        String requestMessage = "GET / HTTP/1.1\r\n"
+                + "\r\n";
+
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(requestMessage.getBytes());
+
+        initHttpRequestAndResponse(inputStream);
+
+        //when
+        fileController.process(httpRequest, httpResponse);
+
+        //then
+        softAssertions.assertThat(httpResponse.getStatus()).isEqualTo(HttpStatus.OK);
+        softAssertions.assertThat(httpResponse.get(HttpField.CONTENT_TYPE)).isEqualTo("text/html;charset=utf-8");
+        softAssertions.assertThat(Integer.parseInt(httpResponse.get(HttpField.CONTENT_LENGTH))).isGreaterThan(6000);
+    }
+
+    @Test
+    @DisplayName("/index.html 페이지 요청에 대한 응답을 검증한다")
+    void getIndexTest() throws Exception {
+        //given
+        String requestMessage = "GET /index.html HTTP/1.1\r\n"
+                + "\r\n";
+
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(requestMessage.getBytes());
+
+        initHttpRequestAndResponse(inputStream);
+
+        //when
+        fileController.process(httpRequest, httpResponse);
+
+        //then
+        softAssertions.assertThat(httpResponse.getStatus()).isEqualTo(HttpStatus.OK);
+        softAssertions.assertThat(httpResponse.get(HttpField.CONTENT_TYPE)).isEqualTo("text/html;charset=utf-8");
+        softAssertions.assertThat(Integer.parseInt(httpResponse.get(HttpField.CONTENT_LENGTH))).isGreaterThan(6000);
+    }
+    
+    @Test
+    @DisplayName("유효하지 않은 리소스 요청에 대한 응답은 '404 NOT FOUND'이어야 한다")
+    void notFoundTest() throws Exception {
+        //given
+        String requestMessage = "GET /invalid-page.aaa HTTP/1.1\r\n"
+                + "\r\n";
+
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(requestMessage.getBytes());
+
+        initHttpRequestAndResponse(inputStream);
+
+        //when
+        fileController.process(httpRequest, httpResponse);
+
+        //then
+        softAssertions.assertThat(httpResponse.getStatus()).isEqualTo(HttpStatus.NOT_FOUND);
+    }
+
+    private void initHttpRequestAndResponse(InputStream in) throws IOException {
+        httpRequest = new HttpRequest(in);
+        httpResponse = new HttpResponse();
+    }
+
+    @Test
+    @DisplayName("응답 파일의 MIME 타입을 Content-Type에 설정하여 응답해야 한다")
+    void MIME() throws Exception {
+        //given
+        String requestMessage = "GET /fonts/glyphicons-halflings-regular.eot HTTP/1.1\r\n"
+                + "\r\n";
+
+        ByteArrayInputStream inputStream = new ByteArrayInputStream(requestMessage.getBytes());
+
+        initHttpRequestAndResponse(inputStream);
+
+        //when
+        fileController.process(httpRequest, httpResponse);
+
+        //then
+        softAssertions.assertThat(httpResponse.get(HttpField.CONTENT_TYPE)).isEqualTo("application/vnd.ms-fontobject");
+    }
+}

--- a/src/test/java/webserver/controller/UserSaveControllerTest.java
+++ b/src/test/java/webserver/controller/UserSaveControllerTest.java
@@ -31,11 +31,14 @@ class UserSaveControllerTest {
     @DisplayName("회원가입 요청 시, Database에 회원 정보가 저장되어야 한다.")
     void userSaveTest() throws Exception {
         //given
-        String requestMessage = "GET /user/create?userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net HTTP/1.1\r\n" +
+        String requestMessage = "POST /user/create HTTP/1.1\r\n" +
                 "Host: localhost:8080\r\n" +
                 "Connection: keep-alive\r\n" +
+                "Content-Length: 93\r\n" +
+                "Content-Type: application/x-www-form-urlencoded\r\n" +
                 "Accept: */*\r\n" +
-                "\r\n";
+                "\r\n" +
+                "userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net";
 
         HttpRequest httpRequest = createHttpRequest(requestMessage);
 
@@ -58,11 +61,14 @@ class UserSaveControllerTest {
     @DisplayName("회원가입 요청 시, 누락된 URL 파라미터가 있으면 BAD REQUESET로 응답한다")
     void userSaveRequestWithMissingParameter() throws Exception {
         //given
-        String requestMessageWithoutUserIdParameter = "GET /user/create?&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net HTTP/1.1\r\n" +
+        String requestMessageWithoutUserIdParameter = "POST /user/create HTTP/1.1\r\n" +
                 "Host: localhost:8080\r\n" +
                 "Connection: keep-alive\r\n" +
+                "Content-Length: 78\r\n" +
+                "Content-Type: application/x-www-form-urlencoded\r\n" +
                 "Accept: */*\r\n" +
-                "\r\n";
+                "\r\n" +
+                "&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net";
 
         HttpRequest httpRequest = createHttpRequest(requestMessageWithoutUserIdParameter);
 
@@ -77,11 +83,14 @@ class UserSaveControllerTest {
     @DisplayName("회원가입 요청 시, 입력하지 않은 회원정보가 있으면 BAD REQUEST로 응답한다")
     void userSaveRequestWithEmptyParameter() throws Exception {
         //given
-        String requestMessageWithEmptyUserId = "GET /user/create?userId=&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net HTTP/1.1\r\n" +
+        String requestMessageWithEmptyUserId = "POST /user/create HTTP/1.1\r\n" +
                 "Host: localhost:8080\r\n" +
                 "Connection: keep-alive\r\n" +
+                "Content-Length: 85\r\n" +
+                "Content-Type: application/x-www-form-urlencoded\r\n" +
                 "Accept: */*\r\n" +
-                "\r\n";
+                "\r\n" +
+                "userId=&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net";
 
         HttpRequest httpRequest = createHttpRequest(requestMessageWithEmptyUserId);
 
@@ -100,11 +109,14 @@ class UserSaveControllerTest {
         Database.addUser(user);
 
         //when
-        String requestMessage = "GET /user/create?userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net HTTP/1.1\r\n" +
+        String requestMessage = "POST /user/create HTTP/1.1\r\n" +
                 "Host: localhost:8080\r\n" +
                 "Connection: keep-alive\r\n" +
+                "Content-Length: 93\r\n" +
+                "Content-Type: application/x-www-form-urlencoded\r\n" +
                 "Accept: */*\r\n" +
-                "\r\n";
+                "\r\n" +
+                "userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net";
 
         HttpRequest httpRequest = createHttpRequest(requestMessage);
 

--- a/src/test/java/webserver/http/HttpRequestTest.java
+++ b/src/test/java/webserver/http/HttpRequestTest.java
@@ -57,20 +57,15 @@ class HttpRequestTest {
     @DisplayName("HTTP Request 메시지의 바디를 파싱할 수 있어야 한다")
     void createWithBody() {
         //given
-        String requestBody = "This is the sample request body data.\r\n" +
-                        "It contains multiple lines.\r\n" +
-                        "This is line 3.\r\n" +
-                        "And here's the final line.";
+        String requestBody = "rqwnlrkqlwrnlqwnrklqwn wnkelnqwlk eqwen kqwlne qwe qw\r\n" +
+                "wqenklwqnelkqwnke enklwqnekl qwe klqwnel wq\r\n" +
+                "wqknenwqlenklwq neklwqn eqwnkelqw";
 
-        String requestMessage = "GET /hello-world HTTP/1.1\r\n" +
-                "Host: localhost:8080\r\n" +
-                "User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:90.0) Gecko/20100101 Firefox/90.0\r\n" +
-                "Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8\r\n" +
-                "Accept-Language: en-US,en;q=0.5\r\n" +
-                "Accept-Encoding: gzip, deflate\r\n" +
-                "Connection: keep-alive\r\n" +
-                "Upgrade-Insecure-Requests: 1\r\n" +
-                "Cache-Control: max-age=0\r\n" +
+        String requestMessage = "POST /api/endpoint HTTP/1.1\r\n" +
+                "Host: example.com\r\n" +
+                "Content-Type: application/json\r\n" +
+                "Content-Length: " + requestBody.length() + "\r\n" +
+                "Authorization: Bearer your_access_token\r\n" +
                 "\r\n" +
                 requestBody;
 
@@ -81,7 +76,7 @@ class HttpRequestTest {
             HttpRequest httpRequest = new HttpRequest(inputStream);
 
             //then
-            Assertions.assertEquals(httpRequest.getBody(), requestBody);
+            Assertions.assertEquals(requestBody, httpRequest.getBody());
         } catch (IOException e) {
             e.printStackTrace();
         }

--- a/src/test/java/webserver/http/HttpResponseTest.java
+++ b/src/test/java/webserver/http/HttpResponseTest.java
@@ -3,6 +3,7 @@ package webserver.http;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import webserver.utils.HttpField;
 
 class HttpResponseTest {
     @Test
@@ -20,7 +21,7 @@ class HttpResponseTest {
         httpResponse.setStatus(HttpStatus.OK);
         httpResponse.setContentType("text/html;charset=utf-8");
         httpResponse.setContentLength(0);
-        httpResponse.setHeader(HttpConstant.AUTHORIZATION, "Bearer ABCD1234");
+        httpResponse.setHeader(HttpField.AUTHORIZATION, "Bearer ABCD1234");
 
         //then
         Assertions.assertEquals(responseMessage, httpResponse.getHeaderMessage());

--- a/src/test/java/webserver/http/HttpResponseTest.java
+++ b/src/test/java/webserver/http/HttpResponseTest.java
@@ -13,18 +13,17 @@ class HttpResponseTest {
         HttpResponse httpResponse = new HttpResponse();
 
         String responseMessage = "HTTP/1.1 200 OK\r\n" +
-                "Content-Type: text/html;charset=utf-8\r\n" +
+                "Authorization: Bearer ABCD1234\r\n" +
                 "Content-Length: 0\r\n" +
-                "Authorization: Bearer ABCD1234\r\n";
+                "Content-Type: text/html;charset=utf-8\r\n";
 
         //when
         httpResponse.setStatus(HttpStatus.OK);
-        httpResponse.setContentType("text/html;charset=utf-8");
-        httpResponse.setContentLength(0);
-        httpResponse.setHeader(HttpField.AUTHORIZATION, "Bearer ABCD1234");
+        httpResponse.set(HttpField.CONTENT_TYPE, "text/html;charset=utf-8");
+        httpResponse.set(HttpField.CONTENT_LENGTH, 0);
+        httpResponse.set(HttpField.AUTHORIZATION, "Bearer ABCD1234");
 
         //then
         Assertions.assertEquals(responseMessage, httpResponse.getHeaderMessage());
     }
-
 }


### PR DESCRIPTION
## 구현 내용
- HTTP 헤더와 쿼리 매개변수 컬렉션에 일급 컬렉션 적용
- 파일 응답 컨트롤러 추가
- 회원가입 요청 방식을 GET에서 POST로 변경
- 회원가입 완료 시, /index.html 페이지로 이동
- HTTP 요청 메시지 파싱 기능 리팩토링

## 고민 사항
- 어떤 객체를 메서드에 전달할 때, 전달하기 전에 null 체크를 할지, 전달받은 메서드에서 null 체크를 해야 될지
- Content-Length는 인코딩 전의 길이인지, 인코딩 후의 길이인지
- API의 Method를 변경한 경우, 'refactor' vs 'feat'
- 컨트롤러를 유틸리티 클래스로 구현할 지, 싱글톤 객체로 구현할지지
- 컨트롤러가 싱글톤일 경우, 동시성 문제를 어떻게 처리해야 할지
- 기존에 HTTP 요청 메시지의 바디를 BufferedReader의 ready()와 readline()으로 처리했는데, ready()는 호출 시점에 스트림 데이터가 서버에 도착하기 전에 호출될 수 있는 불확실성이 존재하고, Request body를 readline()으로 처리하는 경우에는 body의 마지막에 개행문자가 없으면 쓰레드가 blocking 되는 문제가 발생할 수 있다. 기존의 ready()와 readline()을 사용하는 대신, Content-Length와 read()를 활용하는 방식으로 변경하니 기적같이 모든 문제가 해결되었다. 발생했던 문제는 서버가 요청 메시지를 수신받지 못하거나 클라이언트가 응답 메시지를 전달받지 못했던 문제였다. 지금 보니 패킷이 전달되지 않았던 게 아니라, 쓰레드가 blocking 되었거나 ready()가 false일 시 응답패킷을 보내지 않아 발생한 문제인 것 같다.

## 기타
- 개발에 있어 자신이 작성한 코드를 모두 이해하고 한 줄 한 줄에 뜻이 있어야 하는 이유를 뼈저리게 느꼈다. 그저 해프닝이 아닌 나에게 경각심을 준 큰 의미있는 경험이었다.
- 성심성의껏 도와주신 호눅스 님, 일규 님 정말 감사합니다 🙇