### PR TITLE
[이요환] Step-3 다양한 컨텐츠 타입 지원

### DIFF
--- a/src/main/java/Application/Controller/Controller.java
+++ b/src/main/java/Application/Controller/Controller.java
@@ -1,8 +1,8 @@
-package Controller;
+package Application.Controller;
 
-import db.Database;
-import exceptions.BadRequestException;
-import model.User;
+import Application.db.Database;
+import webserver.exceptions.BadRequestException;
+import Application.model.User;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import webserver.annotations.HandleRequest;

--- a/src/main/java/Application/db/Database.java
+++ b/src/main/java/Application/db/Database.java
@@ -1,7 +1,7 @@
-package db;
+package Application.db;
 
-import exceptions.BadRequestException;
-import model.User;
+import webserver.exceptions.BadRequestException;
+import Application.model.User;
 
 import java.util.Collection;
 import java.util.Map;

--- a/src/main/java/Application/model/User.java
+++ b/src/main/java/Application/model/User.java
@@ -1,6 +1,6 @@
-package model;
+package Application.model;
 
-import exceptions.BadRequestException;
+import webserver.exceptions.BadRequestException;
 
 import java.util.Map;
 import java.util.Objects;

--- a/src/main/java/Controller/Controller.java
+++ b/src/main/java/Controller/Controller.java
@@ -1,14 +1,18 @@
 package Controller;
 
 import db.Database;
-import exceptions.IllegalParameterException;
+import exceptions.BadRequestException;
 import model.User;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import webserver.annotations.HandleRequest;
 import webserver.http.message.*;
 
 import java.util.Map;
 
 public class Controller {
+    private static final Logger logger = LoggerFactory.getLogger(Controller.class);
+
     private static class SingletonHelper {
         private static final Controller CONTROLLER = new Controller();
     }
@@ -24,7 +28,8 @@ public class Controller {
             User user = User.of(uri.getParameters());
 
             Database.addUser(user);
-        } catch (IllegalParameterException e) {
+        } catch (BadRequestException e) {
+            logger.error(e.getMessage());
             return HttpResponse.generateHttpResponse(StatusCode.BAD_REQUEST);
         }
 

--- a/src/main/java/Controller/Controller.java
+++ b/src/main/java/Controller/Controller.java
@@ -7,6 +7,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import webserver.annotations.HandleRequest;
 import webserver.http.message.*;
+import webserver.utils.HttpHeaderUtils;
 
 import java.util.Map;
 
@@ -30,10 +31,15 @@ public class Controller {
             Database.addUser(user);
         } catch (BadRequestException e) {
             logger.error(e.getMessage());
-            return HttpResponse.generateHttpResponse(StatusCode.BAD_REQUEST);
+            return new HttpResponse.Builder()
+                    .statusCode(StatusCode.BAD_REQUEST)
+                    .build();
         }
 
-        return HttpResponse.generateHttpResponse(StatusCode.FOUND, Map.of("Location", "http://localhost:8080/index.html"));
+        return new HttpResponse.Builder()
+                .statusCode(StatusCode.FOUND)
+                .headers(Map.of(HttpHeaderUtils.LOCATION_HEADER, "http://localhost:8080/index.html"))
+                .build();
     }
 }
 

--- a/src/main/java/Controller/Controller.java
+++ b/src/main/java/Controller/Controller.java
@@ -6,6 +6,8 @@ import model.User;
 import webserver.annotations.HandleRequest;
 import webserver.http.message.*;
 
+import java.util.Map;
+
 public class Controller {
     private static class SingletonHelper {
         private static final Controller CONTROLLER = new Controller();
@@ -14,6 +16,7 @@ public class Controller {
     public static Controller getInstance() {
         return SingletonHelper.CONTROLLER;
     }
+
     @HandleRequest(path = "/user/create", httpMethod = HttpMethod.GET)
     public HttpResponse createUser(HttpRequest httpRequest) {
         try {
@@ -25,6 +28,7 @@ public class Controller {
             return HttpResponse.generateHttpResponse(StatusCode.BAD_REQUEST);
         }
 
-        return HttpResponse.generateHttpResponse(StatusCode.OK);
+        return HttpResponse.generateHttpResponse(StatusCode.FOUND, Map.of("Location", "http://localhost:8080/index.html"));
     }
 }
+

--- a/src/main/java/Controller/Controller.java
+++ b/src/main/java/Controller/Controller.java
@@ -6,6 +6,7 @@ import model.User;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import webserver.annotations.HandleRequest;
+import webserver.annotations.QueryParameter;
 import webserver.http.message.*;
 import webserver.utils.HttpHeaderUtils;
 
@@ -23,11 +24,14 @@ public class Controller {
     }
 
     @HandleRequest(path = "/user/create", httpMethod = HttpMethod.GET)
-    public HttpResponse createUser(HttpRequest httpRequest) {
+    public HttpResponse createUser(@QueryParameter(key = "userId") String userId,
+                                   @QueryParameter(key = "password")String password,
+                                   @QueryParameter(key = "name") String name,
+                                   @QueryParameter(key = "email") String email /*HttpRequest httpRequest*/) {
         try {
-            URI uri = httpRequest.getURI();
-            User user = User.of(uri.getParameters());
-
+//            URI uri = httpRequest.getURI();
+//            User user = User.of(uri.getParameters());
+            User user = new User(userId, password, name, email);
             Database.addUser(user);
         } catch (BadRequestException e) {
             logger.error(e.getMessage());

--- a/src/main/java/db/Database.java
+++ b/src/main/java/db/Database.java
@@ -2,6 +2,7 @@ package db;
 
 import com.google.common.collect.Maps;
 
+import exceptions.BadRequestException;
 import model.User;
 
 import java.util.Collection;
@@ -10,7 +11,10 @@ import java.util.Map;
 public class Database {
     private static Map<String, User> users = Maps.newHashMap();
 
-    public static void addUser(User user) {
+    public static void addUser(User user) throws BadRequestException {
+        if (users.containsKey(user.getUserId())) {
+            throw new BadRequestException("이미 존재하는 유저 정보");
+        }
         users.put(user.getUserId(), user);
     }
 

--- a/src/main/java/db/Database.java
+++ b/src/main/java/db/Database.java
@@ -1,21 +1,24 @@
 package db;
 
-import com.google.common.collect.Maps;
-
 import exceptions.BadRequestException;
 import model.User;
 
 import java.util.Collection;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 public class Database {
-    private static Map<String, User> users = Maps.newHashMap();
+    private static Map<String, User> users = new ConcurrentHashMap<>();
 
     public static void addUser(User user) throws BadRequestException {
-        if (users.containsKey(user.getUserId())) {
+        User existingUser = users.putIfAbsent(user.getUserId(), user);
+        verifyDuplicatedInput(existingUser);
+    }
+
+    private static void verifyDuplicatedInput(User existingUser) throws BadRequestException {
+        if (existingUser != null) {
             throw new BadRequestException("이미 존재하는 유저 정보");
         }
-        users.put(user.getUserId(), user);
     }
 
     public static User findUserById(String userId) {

--- a/src/main/java/db/Database.java
+++ b/src/main/java/db/Database.java
@@ -15,6 +15,10 @@ public class Database {
         verifyDuplicatedInput(existingUser);
     }
 
+    public static void clear() {
+        users.clear();
+    }
+
     private static void verifyDuplicatedInput(User existingUser) throws BadRequestException {
         if (existingUser != null) {
             throw new BadRequestException("이미 존재하는 유저 정보");

--- a/src/main/java/exceptions/BadRequestException.java
+++ b/src/main/java/exceptions/BadRequestException.java
@@ -1,0 +1,7 @@
+package exceptions;
+
+public class BadRequestException extends Exception {
+    public BadRequestException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/exceptions/IllegalParameterException.java
+++ b/src/main/java/exceptions/IllegalParameterException.java
@@ -1,7 +1,0 @@
-package exceptions;
-
-public class IllegalParameterException extends NullPointerException {
-    public IllegalParameterException() {
-        super("유효하지 않은 매개변수");
-    }
-}

--- a/src/main/java/model/User.java
+++ b/src/main/java/model/User.java
@@ -1,6 +1,6 @@
 package model;
 
-import exceptions.IllegalParameterException;
+import exceptions.BadRequestException;
 
 import java.util.Map;
 import java.util.Objects;
@@ -34,7 +34,7 @@ public class User {
         return email;
     }
 
-    public static User of(Map<String, String> parameters) {
+    public static User of(Map<String, String> parameters) throws BadRequestException {
         verifyUserParameters(parameters);
 
         String userId = parameters.get("userId");
@@ -45,12 +45,12 @@ public class User {
         return new User(userId, password, name, email);
     }
 
-    private static void verifyUserParameters(Map<String, String> parameters) {
+    private static void verifyUserParameters(Map<String, String> parameters) throws BadRequestException {
         if (!parameters.containsKey("userId")
                 || !parameters.containsKey("password")
                 || !parameters.containsKey("name")
                 || !parameters.containsKey("email")) {
-            throw new IllegalParameterException();
+            throw new BadRequestException("유효하지 않은 쿼리 매개변수");
         }
     }
     @Override

--- a/src/main/java/model/User.java
+++ b/src/main/java/model/User.java
@@ -35,23 +35,12 @@ public class User {
     }
 
     public static User of(Map<String, String> parameters) throws BadRequestException {
-        verifyUserParameters(parameters);
-
         String userId = parameters.get("userId");
         String password = parameters.get("password");
         String name = parameters.get("name");
         String email = parameters.get("email");
 
         return new User(userId, password, name, email);
-    }
-
-    private static void verifyUserParameters(Map<String, String> parameters) throws BadRequestException {
-        if (!parameters.containsKey("userId")
-                || !parameters.containsKey("password")
-                || !parameters.containsKey("name")
-                || !parameters.containsKey("email")) {
-            throw new BadRequestException("유효하지 않은 쿼리 매개변수");
-        }
     }
     @Override
     public boolean equals(Object o) {

--- a/src/main/java/webserver/annotations/HandleRequest.java
+++ b/src/main/java/webserver/annotations/HandleRequest.java
@@ -8,7 +8,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 @Target({ElementType.METHOD})
-@Retention(RetentionPolicy.RUNTIME) //컴파일 시에만 필요한 것 맞는지?
+@Retention(RetentionPolicy.RUNTIME)
 public @interface HandleRequest {
     String path();
     HttpMethod httpMethod();

--- a/src/main/java/webserver/annotations/QueryParameter.java
+++ b/src/main/java/webserver/annotations/QueryParameter.java
@@ -1,0 +1,12 @@
+package webserver.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface QueryParameter {
+    String key();
+}

--- a/src/main/java/webserver/exceptions/BadRequestException.java
+++ b/src/main/java/webserver/exceptions/BadRequestException.java
@@ -1,4 +1,4 @@
-package exceptions;
+package webserver.exceptions;
 
 public class BadRequestException extends Exception {
     public BadRequestException(String message) {

--- a/src/main/java/webserver/exceptions/PathNotFoundException.java
+++ b/src/main/java/webserver/exceptions/PathNotFoundException.java
@@ -1,4 +1,4 @@
-package exceptions;
+package webserver.exceptions;
 
 public class PathNotFoundException extends RuntimeException {
     public PathNotFoundException() {

--- a/src/main/java/webserver/handlers/HttpRequestRouter.java
+++ b/src/main/java/webserver/handlers/HttpRequestRouter.java
@@ -12,10 +12,10 @@ import java.lang.reflect.Method;
 
 public class HttpRequestRouter {
     //set default for test
-    static HttpMethodHandlerMappings requestMappings;
+    static HttpMethodHandlerMapping requestMappings;
 
     static {
-        requestMappings = new HttpMethodHandlerMappings();
+        requestMappings = new HttpMethodHandlerMapping();
         requestMappings.initialize();
 
         Method[] methods = Controller.class.getDeclaredMethods();

--- a/src/main/java/webserver/handlers/HttpRequestRouter.java
+++ b/src/main/java/webserver/handlers/HttpRequestRouter.java
@@ -51,7 +51,9 @@ public class HttpRequestRouter {
 
             return httpResponse;
         } catch (PathNotFoundException e) {
-            return HttpResponse.generateHttpResponse(StatusCode.NOT_FOUND);
+            return new HttpResponse.Builder()
+                    .statusCode(StatusCode.NOT_FOUND)
+                    .build();
         }
     }
 }

--- a/src/main/java/webserver/handlers/HttpRequestRouter.java
+++ b/src/main/java/webserver/handlers/HttpRequestRouter.java
@@ -1,8 +1,8 @@
 package webserver.handlers;
 
-import Controller.Controller;
-import exceptions.BadRequestException;
-import exceptions.PathNotFoundException;
+import Application.Controller.Controller;
+import webserver.exceptions.BadRequestException;
+import webserver.exceptions.PathNotFoundException;
 import webserver.annotations.HandleRequest;
 import webserver.annotations.QueryParameter;
 import webserver.http.HttpMethodHandlerMapping;

--- a/src/main/java/webserver/handlers/HttpRequestRouter.java
+++ b/src/main/java/webserver/handlers/HttpRequestRouter.java
@@ -42,9 +42,10 @@ public class HttpRequestRouter {
 
         try {
             if (uri.hasExtension()) {
-                byte[] body = StaticResourceHandler.getStaticResource(uri.getPath());
-                return HttpResponse.generateHttpResponse(StatusCode.OK, body);
+                HttpResponse httpResponse = StaticResourceHandler.handle(httpRequest);
+                return httpResponse;
             }
+
             Method method = requestMappings.getMappedMethod(uri.getPath(), httpMethod);
             HttpResponse httpResponse = (HttpResponse) method.invoke(Controller.getInstance(), httpRequest);
 

--- a/src/main/java/webserver/handlers/StaticResourceHandler.java
+++ b/src/main/java/webserver/handlers/StaticResourceHandler.java
@@ -1,6 +1,6 @@
 package webserver.handlers;
 
-import exceptions.PathNotFoundException;
+import webserver.exceptions.PathNotFoundException;
 import webserver.http.message.*;
 import webserver.utils.HttpHeaderUtils;
 

--- a/src/main/java/webserver/handlers/StaticResourceHandler.java
+++ b/src/main/java/webserver/handlers/StaticResourceHandler.java
@@ -1,22 +1,53 @@
 package webserver.handlers;
 
 import exceptions.PathNotFoundException;
+import webserver.http.message.HttpRequest;
+import webserver.http.message.HttpResponse;
+import webserver.http.message.StatusCode;
+import webserver.http.message.URI;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 
 public class StaticResourceHandler {
-    public static final String TEMPLATES_PATH = "/Users/yohwan/IdeaProjects/be-was/src/main/resources/templates";
+    public static final String PROJECT_ROOT_PATH = System.getProperty("user.dir");
+    public static final String TEMPLATES_PATH = "/src/main/resources/templates";
+    public static final String STATIC_PATH = "/src/main/resources/static";
 
-    public static byte[] getStaticResource(String resourcePath) throws IOException {
-        String fullPath = TEMPLATES_PATH + resourcePath;
-        File file = new File(fullPath);
+    public static HttpResponse handle(HttpRequest httpRequest) throws IOException {
+        byte[] body = getResource(httpRequest.getURI());
+
+        return HttpResponse.generateHttpResponse(StatusCode.OK, body);
+    }
+
+    private static byte[] getResource(URI uri) throws IOException {
+        String fullPath = PROJECT_ROOT_PATH + TEMPLATES_PATH + uri.getPath();
+        if (uri.hasMIMEForStaticResource()) {
+            fullPath = PROJECT_ROOT_PATH + STATIC_PATH + uri.getPath();
+        }
+        return readFile(fullPath);
+    }
+
+    private static byte[] readFile(String path) throws IOException {
+        File file = new File(path);
 
         if (!file.exists() || !file.isFile()) {
             throw new PathNotFoundException();
         }
 
         return Files.readAllBytes(file.toPath());
+    }
+
+    public static byte[] getResourceForTest(URI uri) throws IOException {
+        String fullPath = PROJECT_ROOT_PATH + TEMPLATES_PATH + uri.getPath();
+        if (uri.hasMIMEForStaticResource()) {
+            fullPath = PROJECT_ROOT_PATH + STATIC_PATH + uri.getPath();
+        }
+        return readFile(fullPath);
+    }
+
+    public static void main(String[] args) {
+        System.out.println(System.getProperty("user.dir"));
     }
 }

--- a/src/main/java/webserver/handlers/StaticResourceHandler.java
+++ b/src/main/java/webserver/handlers/StaticResourceHandler.java
@@ -1,14 +1,13 @@
 package webserver.handlers;
 
 import exceptions.PathNotFoundException;
-import webserver.http.message.HttpRequest;
-import webserver.http.message.HttpResponse;
-import webserver.http.message.StatusCode;
-import webserver.http.message.URI;
+import webserver.http.message.*;
+import webserver.utils.HttpHeaderUtils;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.util.Map;
 
 public class StaticResourceHandler {
     public static final String PROJECT_ROOT_PATH = System.getProperty("user.dir");
@@ -16,9 +15,17 @@ public class StaticResourceHandler {
     public static final String STATIC_PATH = "/src/main/resources/static";
 
     public static HttpResponse handle(HttpRequest httpRequest) throws IOException {
-        byte[] body = getResource(httpRequest.getURI());
+        URI uri = httpRequest.getURI();
 
-        return HttpResponse.generateHttpResponse(StatusCode.OK, body);
+        byte[] body = getResource(uri);
+        MIME mime = uri.getExtension().get();
+
+        Map<String, String> headers = Map.of(HttpHeaderUtils.CONTENT_TYPE_HEADER,
+                mime.contentType,
+                HttpHeaderUtils.CONTENT_LENGTH_HEADER,
+                String.valueOf(body.length));
+
+        return HttpResponse.generateHttpResponse(StatusCode.OK, headers, body);
     }
 
     private static byte[] getResource(URI uri) throws IOException {

--- a/src/main/java/webserver/handlers/StaticResourceHandler.java
+++ b/src/main/java/webserver/handlers/StaticResourceHandler.java
@@ -25,7 +25,10 @@ public class StaticResourceHandler {
                 HttpHeaderUtils.CONTENT_LENGTH_HEADER,
                 String.valueOf(body.length));
 
-        return HttpResponse.generateHttpResponse(StatusCode.OK, headers, body);
+        return new HttpResponse.Builder()
+                .headers(headers)
+                .body(body)
+                .build();
     }
 
     private static byte[] getResource(URI uri) throws IOException {

--- a/src/main/java/webserver/http/HttpMethodHandlerMapping.java
+++ b/src/main/java/webserver/http/HttpMethodHandlerMapping.java
@@ -6,26 +6,26 @@ import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Map;
 
-public class HttpMethodHandlerMappings {
-    private Map<HttpMethod, URIHandlers> requestMappings;
+public class HttpMethodHandlerMapping {
+    private Map<HttpMethod, URIHandlerMapping> requestMappings;
 
-    public HttpMethodHandlerMappings() {
+    public HttpMethodHandlerMapping() {
         this.requestMappings = new HashMap<>();
     }
 
     public void initialize() {
         for (HttpMethod httpMethod : HttpMethod.values()) {
-            requestMappings.put(httpMethod, new URIHandlers());
+            requestMappings.put(httpMethod, new URIHandlerMapping());
         }
     }
 
     public void addMapping(String path, HttpMethod httpMethod, Method method) {
-        URIHandlers uriHandlers = requestMappings.get(httpMethod);
+        URIHandlerMapping uriHandlers = requestMappings.get(httpMethod);
         uriHandlers.addMapping(path, method);
     }
 
     public Method getMappedMethod(String path, HttpMethod httpMethod) {
-        URIHandlers uriHandlers = requestMappings.get(httpMethod);
+        URIHandlerMapping uriHandlers = requestMappings.get(httpMethod);
 
         return uriHandlers.getMappedMethod(path);
     }

--- a/src/main/java/webserver/http/URIHandlerMapping.java
+++ b/src/main/java/webserver/http/URIHandlerMapping.java
@@ -1,6 +1,6 @@
 package webserver.http;
 
-import exceptions.PathNotFoundException;
+import webserver.exceptions.PathNotFoundException;
 
 import java.lang.reflect.Method;
 import java.util.HashMap;

--- a/src/main/java/webserver/http/URIHandlerMapping.java
+++ b/src/main/java/webserver/http/URIHandlerMapping.java
@@ -6,10 +6,10 @@ import java.lang.reflect.Method;
 import java.util.HashMap;
 import java.util.Map;
 
-public class URIHandlers {
+public class URIHandlerMapping {
     private Map<String, Method> map;
 
-    public URIHandlers() {
+    public URIHandlerMapping() {
         this.map = new HashMap<>();
     }
 

--- a/src/main/java/webserver/http/message/HttpResponse.java
+++ b/src/main/java/webserver/http/message/HttpResponse.java
@@ -1,5 +1,7 @@
 package webserver.http.message;
 
+import webserver.utils.HttpHeaderUtils;
+
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Objects;
@@ -14,10 +16,10 @@ public class HttpResponse {
 
     private final byte[] body;
 
-    private HttpResponse(String version, StatusCode statusCode, Map<String, String> metadata, byte[] body) {
+    private HttpResponse(String version, StatusCode statusCode, Map<String, String> headers, byte[] body) {
         this.version = version;
         this.statusCode = statusCode;
-        this.headers = metadata;
+        this.headers = headers;
         this.body = body;
     }
 
@@ -34,6 +36,10 @@ public class HttpResponse {
 
     public static HttpResponse generateHttpResponse(StatusCode statusCode) {
         return new HttpResponse(statusCode, new byte[]{});
+    }
+
+    public static HttpResponse generateHttpResponse(StatusCode statusCode, Map<String, String> headers) {
+        return new HttpResponse(HttpHeaderUtils.DEFAULT_HTTP_VERSION, statusCode, headers, new byte[]{});
     }
 
     public byte[] getBody() {

--- a/src/main/java/webserver/http/message/HttpResponse.java
+++ b/src/main/java/webserver/http/message/HttpResponse.java
@@ -6,8 +6,6 @@ import java.util.Arrays;
 import java.util.Map;
 import java.util.Objects;
 
-import static webserver.utils.HttpHeaderUtils.*;
-
 public class HttpResponse {
     private final String version;
     private final StatusCode statusCode;
@@ -16,34 +14,55 @@ public class HttpResponse {
 
     private final byte[] body;
 
+    public static class Builder {
+        private String version;
+        private StatusCode statusCode;
+        private Map<String, String> headers;
+        private byte[] body;
+
+        public Builder version(String version) {
+            this.version = version;
+            return this;
+        }
+
+        public Builder statusCode(StatusCode statusCode) {
+            this.statusCode = statusCode;
+            return this;
+        }
+
+        public Builder headers(Map<String, String> headers) {
+            this.headers = headers;
+            return this;
+        }
+
+        public Builder body(byte[] body) {
+            this.body = body;
+            return this;
+        }
+
+        public HttpResponse build() {
+            if (version == null) {
+                version = HttpHeaderUtils.DEFAULT_HTTP_VERSION;
+            }
+            if (headers == null) {
+                headers = Map.of();
+            }
+            if (body == null) {
+                body = new byte[]{};
+            }
+            if (statusCode == null) {
+                statusCode = StatusCode.OK;
+            }
+
+            return new HttpResponse(version, statusCode, headers, body);
+        }
+    }
+
     private HttpResponse(String version, StatusCode statusCode, Map<String, String> headers, byte[] body) {
         this.version = version;
         this.statusCode = statusCode;
         this.headers = headers;
         this.body = body;
-    }
-
-    public HttpResponse(StatusCode statusCode, byte[] body) {
-        this.version = DEFAULT_HTTP_VERSION;
-        this.headers = Map.of(CONTENT_TYPE_HEADER, DEFAULT_CONTENT_TYPE_VALUE, CONTENT_LENGTH_HEADER, String.valueOf(body.length));
-        this.statusCode = statusCode;
-        this.body = body;
-    }
-
-    public static HttpResponse generateHttpResponse(StatusCode statusCode, byte[] body) {
-        return new HttpResponse(statusCode, body);
-    }
-
-    public static HttpResponse generateHttpResponse(StatusCode statusCode) {
-        return new HttpResponse(statusCode, new byte[]{});
-    }
-
-    public static HttpResponse generateHttpResponse(StatusCode statusCode, Map<String, String> headers) {
-        return new HttpResponse(HttpHeaderUtils.DEFAULT_HTTP_VERSION, statusCode, headers, new byte[]{});
-    }
-
-    public static HttpResponse generateHttpResponse(StatusCode statusCode, Map<String, String> headers, byte[] body) {
-        return new HttpResponse(DEFAULT_HTTP_VERSION, statusCode, headers, body);
     }
 
     public byte[] getBody() {

--- a/src/main/java/webserver/http/message/HttpResponse.java
+++ b/src/main/java/webserver/http/message/HttpResponse.java
@@ -42,6 +42,10 @@ public class HttpResponse {
         return new HttpResponse(HttpHeaderUtils.DEFAULT_HTTP_VERSION, statusCode, headers, new byte[]{});
     }
 
+    public static HttpResponse generateHttpResponse(StatusCode statusCode, Map<String, String> headers, byte[] body) {
+        return new HttpResponse(DEFAULT_HTTP_VERSION, statusCode, headers, body);
+    }
+
     public byte[] getBody() {
         return body;
     }

--- a/src/main/java/webserver/http/message/MIME.java
+++ b/src/main/java/webserver/http/message/MIME.java
@@ -1,0 +1,17 @@
+package webserver.http.message;
+
+public enum MIME {
+    HTML("text/html"),
+    CSS("text/css"),
+    JS("application/javascript"),
+    ICO("image/x-icon"),
+    PNG("image/png"),
+    JPG("image/jpeg"),
+    TXT("text/plain");
+
+    public String contentType;
+
+    MIME(String contentType) {
+        this.contentType = contentType;
+    }
+}

--- a/src/main/java/webserver/http/message/MIME.java
+++ b/src/main/java/webserver/http/message/MIME.java
@@ -7,7 +7,9 @@ public enum MIME {
     ICO("image/x-icon"),
     PNG("image/png"),
     JPG("image/jpeg"),
-    TXT("text/plain");
+    TXT("text/plain"),
+    WOFF("font/WOFF"),
+    TTF("font/ttf");
 
     public String contentType;
 

--- a/src/main/java/webserver/http/message/MIME.java
+++ b/src/main/java/webserver/http/message/MIME.java
@@ -14,4 +14,8 @@ public enum MIME {
     MIME(String contentType) {
         this.contentType = contentType;
     }
+
+    public boolean isTemplate() {
+        return this.equals(MIME.HTML) || this.equals(MIME.TXT);
+    }
 }

--- a/src/main/java/webserver/http/message/StatusCode.java
+++ b/src/main/java/webserver/http/message/StatusCode.java
@@ -4,7 +4,7 @@ public enum StatusCode {
     OK (200, "Ok"),
     CREATED (201, "Created"),
     ACCEPTED (202, "Accepted"),
-    MULTIPLE_CHOICES (300, "Multiple Choiceㄴ"),
+    MULTIPLE_CHOICES (300, "Multiple Choice"),
     MOVED_PERMANENTLY (301, "Moved_Permanently"),
     FOUND (302, "Found"),
     SEE_OTHER(303, "See Other"),
@@ -17,7 +17,7 @@ public enum StatusCode {
     METHOD_NOT_ALLOWED(405, "Method Not Allowed"),
     INTERNAL_SERVER_ERROR(500, "Internal Server Error"),
     NOT_IMPLEMENTED(501, "Not Implemented"),
-    BAD_GATEWAT(502, "Bad Gateway");
+    BAD_GATEWAY(502, "Bad Gateway");
 
     public int codeNumber;
     public String message;

--- a/src/main/java/webserver/http/message/URI.java
+++ b/src/main/java/webserver/http/message/URI.java
@@ -28,6 +28,10 @@ public class URI {
         this.extension = Optional.of(extension);
     }
 
+    public boolean hasMIMEForStaticResource() {
+        return extension.isPresent() && !extension.get().isTemplate();
+    }
+
     public boolean hasParameter() {
         return !parameters.isEmpty();
     }

--- a/src/main/java/webserver/http/message/URI.java
+++ b/src/main/java/webserver/http/message/URI.java
@@ -38,11 +38,17 @@ public class URI {
 
     public boolean hasExtension() {
         return extension.isPresent();
-    };
+    }
+
+    ;
 
 
     public String getPath() {
         return path;
+    }
+
+    public Optional<MIME> getExtension() {
+        return extension;
     }
 
     public Map<String, String> getParameters() {

--- a/src/main/java/webserver/http/message/URI.java
+++ b/src/main/java/webserver/http/message/URI.java
@@ -14,7 +14,7 @@ public class URI {
 
     private final String path;
     private final Map<String, String> parameters;
-    private final Optional<String> extension;
+    private final Optional<MIME> extension;
 
     public URI(String path, Map<String, String> parameters) {
         this.path = path;
@@ -22,7 +22,7 @@ public class URI {
         this.extension = Optional.empty();
     }
 
-    public URI(String path, Map<String, String> parameters, String extension) {
+    public URI(String path, Map<String, String> parameters, MIME extension) {
         this.path = path;
         this.parameters = parameters;
         this.extension = Optional.of(extension);

--- a/src/main/java/webserver/utils/HttpHeaderUtils.java
+++ b/src/main/java/webserver/utils/HttpHeaderUtils.java
@@ -3,7 +3,6 @@ package webserver.utils;
 public class HttpHeaderUtils {
     public static final String CONTENT_TYPE_HEADER = "Content-Type";
     public static final String CONTENT_LENGTH_HEADER = "Content-Length";
-    public static final String DEFAULT_CONTENT_TYPE_VALUE = "text/html;charset=utf-8";
     public static final String DEFAULT_HTTP_VERSION = "HTTP/1.1";
     public static final String LOCATION_HEADER = "Location";
 }

--- a/src/main/java/webserver/utils/HttpHeaderUtils.java
+++ b/src/main/java/webserver/utils/HttpHeaderUtils.java
@@ -5,4 +5,5 @@ public class HttpHeaderUtils {
     public static final String CONTENT_LENGTH_HEADER = "Content-Length";
     public static final String DEFAULT_CONTENT_TYPE_VALUE = "text/html;charset=utf-8";
     public static final String DEFAULT_HTTP_VERSION = "HTTP/1.1";
+    public static final String LOCATION_HEADER = "Location";
 }

--- a/src/main/java/webserver/utils/HttpMessageParser.java
+++ b/src/main/java/webserver/utils/HttpMessageParser.java
@@ -81,7 +81,7 @@ public class HttpMessageParser {
         }
         if (hasExtension(path)) {
             String extension = parseExtension(stringURI);
-            return new URI(path, parameters, extension);
+            return new URI(path, parameters, MIME.valueOf(extension));
         }
         return new URI(path, parameters);
     }

--- a/src/main/java/webserver/utils/HttpMessageParser.java
+++ b/src/main/java/webserver/utils/HttpMessageParser.java
@@ -81,7 +81,7 @@ public class HttpMessageParser {
         }
         if (hasExtension(path)) {
             String extension = parseExtension(stringURI);
-            return new URI(path, parameters, MIME.valueOf(extension));
+            return new URI(path, parameters, MIME.valueOf(extension.toUpperCase()));
         }
         return new URI(path, parameters);
     }

--- a/src/test/java/Controller/ControllerTest.java
+++ b/src/test/java/Controller/ControllerTest.java
@@ -34,10 +34,11 @@ class ControllerTest {
 
         @Test
         @DisplayName("올바른 입력에 대해서 응답으로 302번 코드를 보낸다.")
-        void receive200() {
+        void createUserTest() {
+            Database.clear();
             HttpResponse httpResponse = controller.createUser(httpRequest);
 
-            assertEquals(httpResponse.getStatusCode(), StatusCode.FOUND);
+            assertEquals(StatusCode.FOUND, httpResponse.getStatusCode());
             assertThat(httpResponse.getHeaders().containsKey("Location"));
         }
 

--- a/src/test/java/Controller/ControllerTest.java
+++ b/src/test/java/Controller/ControllerTest.java
@@ -1,7 +1,8 @@
 package Controller;
 
-import db.Database;
-import model.User;
+import Application.Controller.Controller;
+import Application.db.Database;
+import Application.model.User;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;

--- a/src/test/java/Controller/ControllerTest.java
+++ b/src/test/java/Controller/ControllerTest.java
@@ -10,6 +10,7 @@ import webserver.http.message.*;
 
 import java.util.Map;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class ControllerTest {
@@ -32,11 +33,12 @@ class ControllerTest {
         }
 
         @Test
-        @DisplayName("올바른 입력에 대해서 응답으로 200번 코드를 보낸다.")
+        @DisplayName("올바른 입력에 대해서 응답으로 302번 코드를 보낸다.")
         void receive200() {
             HttpResponse httpResponse = controller.createUser(httpRequest);
 
-            assertEquals(httpResponse.getStatusCode(), StatusCode.OK);
+            assertEquals(httpResponse.getStatusCode(), StatusCode.FOUND);
+            assertThat(httpResponse.getHeaders().containsKey("Location"));
         }
 
         @Test

--- a/src/test/java/Controller/ControllerTest.java
+++ b/src/test/java/Controller/ControllerTest.java
@@ -6,9 +6,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import webserver.http.message.*;
-
-import java.util.Map;
+import webserver.http.message.HttpResponse;
+import webserver.http.message.StatusCode;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -18,25 +17,25 @@ class ControllerTest {
     @Nested
     @DisplayName("유저 생성 테스트")
     class CreateUser {
-        HttpRequest httpRequest;
         Controller controller;
-
+        String userId;
+        String password;
+        String name;
+        String email;
         @BeforeEach
         void setup() {
+            Database.clear();
             controller = Controller.getInstance();
-
-            httpRequest = new HttpRequest(HttpMethod.GET,
-                    new URI("/use/create",
-                            Map.of("userId", "userId", "password", "password", "name", "name", "email", "email")),
-                            "HTTP/1.1",
-                            Map.of());
+            userId = "userId";
+            password = "password";
+            name = "name";
+            email = "asdsda@dasads";
         }
 
         @Test
         @DisplayName("올바른 입력에 대해서 응답으로 302번 코드를 보낸다.")
         void createUserTest() {
-            Database.clear();
-            HttpResponse httpResponse = controller.createUser(httpRequest);
+            HttpResponse httpResponse = controller.createUser(userId, password, name, email);
 
             assertEquals(StatusCode.FOUND, httpResponse.getStatusCode());
             assertThat(httpResponse.getHeaders().containsKey("Location"));
@@ -45,10 +44,10 @@ class ControllerTest {
         @Test
         @DisplayName("데이터베이스에 유저 정보를 저장한다.")
         void uploadToDatabase() {
-            controller.createUser(httpRequest);
+            controller.createUser(userId, password, name, email);
 
             User actualUser = Database.findUserById("userId");
-            User expectedUser = new User("userId", "password", "name", "email");
+            User expectedUser = new User(userId, password, name, email);
 
             assertEquals(expectedUser, actualUser);
         }

--- a/src/test/java/db/DatabaseTest.java
+++ b/src/test/java/db/DatabaseTest.java
@@ -1,0 +1,38 @@
+package db;
+
+import exceptions.BadRequestException;
+import model.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class DatabaseTest {
+
+    private User user;
+
+    @BeforeEach
+    void setUp() throws BadRequestException {
+        Map<String, String> userParameters = new HashMap<>();
+        userParameters.put("userId", "john_doe");
+        userParameters.put("password", "secret_password");
+        userParameters.put("name", "John Doe");
+        userParameters.put("email", "john.doe@example.com");
+
+        user = User.of(userParameters);
+    }
+
+    @Test
+    @DisplayName("이미 존재하는 유저일 경우 BadRequestException을 발생시킨다.")
+    void addUser() throws BadRequestException {
+        Database.addUser(user);
+        assertThrows(BadRequestException.class, () -> Database.addUser(user));
+    }
+
+
+
+}

--- a/src/test/java/db/DatabaseTest.java
+++ b/src/test/java/db/DatabaseTest.java
@@ -1,7 +1,8 @@
 package db;
 
-import exceptions.BadRequestException;
-import model.User;
+import Application.db.Database;
+import webserver.exceptions.BadRequestException;
+import Application.model.User;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/model/UserTest.java
+++ b/src/test/java/model/UserTest.java
@@ -9,7 +9,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class UserTest {
 
@@ -42,18 +41,5 @@ class UserTest {
         assertEquals("secret_password", user.getPassword());
         assertEquals("John Doe", user.getName());
         assertEquals("john.doe@example.com", user.getEmail());
-    }
-
-    @Test
-    @DisplayName("parameter 중 하나라도 존재하지 않는 경우 User.of는 BadRequestException을 발생시킨다.")
-    void testUserOfWithMissingParameters() {
-        Map<String, String> invalidParameters = new HashMap<>(validParameters);
-        invalidParameters.remove("name");
-
-        Throwable e = assertThrows(BadRequestException.class, () -> {
-            User.of(invalidParameters);
-        });
-
-        assertEquals("유효하지 않은 쿼리 매개변수", e.getMessage());
     }
 }

--- a/src/test/java/model/UserTest.java
+++ b/src/test/java/model/UserTest.java
@@ -1,6 +1,6 @@
 package model;
 
-import exceptions.IllegalParameterException;
+import exceptions.BadRequestException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -16,7 +16,7 @@ class UserTest {
     private Map<String, String> validParameters;
 
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         validParameters = new HashMap<>();
         validParameters.put("userId", "john_doe");
         validParameters.put("password", "secret_password");
@@ -26,7 +26,7 @@ class UserTest {
 
     @Test
     @DisplayName("생성자로 유효한 User 객체가 생성된다.")
-    public void testUserConstructor() {
+    void testUserConstructor() {
         User user = new User("john_doe", "secret_password", "John Doe", "john.doe@example.com");
         assertEquals("john_doe", user.getUserId());
         assertEquals("secret_password", user.getPassword());
@@ -36,7 +36,7 @@ class UserTest {
 
     @Test
     @DisplayName("Map으로 유효한 User 객체가 생성된다.")
-    public void testUserOf() {
+    void testUserOf() throws BadRequestException {
         User user = User.of(validParameters);
         assertEquals("john_doe", user.getUserId());
         assertEquals("secret_password", user.getPassword());
@@ -45,13 +45,15 @@ class UserTest {
     }
 
     @Test
-    @DisplayName("parameter 중 하나라도 존재하지 않는 경우 User.of는 IllegalParameterException을 발생시킨다.")
-    public void testUserOfWithMissingParameters() {
+    @DisplayName("parameter 중 하나라도 존재하지 않는 경우 User.of는 BadRequestException을 발생시킨다.")
+    void testUserOfWithMissingParameters() {
         Map<String, String> invalidParameters = new HashMap<>(validParameters);
         invalidParameters.remove("name");
 
-        assertThrows(IllegalParameterException.class, () -> {
+        Throwable e = assertThrows(BadRequestException.class, () -> {
             User.of(invalidParameters);
         });
+
+        assertEquals("유효하지 않은 쿼리 매개변수", e.getMessage());
     }
 }

--- a/src/test/java/model/UserTest.java
+++ b/src/test/java/model/UserTest.java
@@ -1,6 +1,7 @@
 package model;
 
-import exceptions.BadRequestException;
+import Application.model.User;
+import webserver.exceptions.BadRequestException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/utils/HttpMessageParserTest.java
+++ b/src/test/java/utils/HttpMessageParserTest.java
@@ -21,7 +21,7 @@ class HttpMessageParserTest {
     @DisplayName("HttpResponse to OutputStream 파싱 로직 테스트")
     void parseHttpResponse() throws IOException {
         //given
-        HttpResponse httpResponse = new HttpResponse(StatusCode.OK, new byte[0]);
+        HttpResponse httpResponse = new HttpResponse.Builder().build();//new HttpResponse(StatusCode.OK, new byte[0]);
 
         //when
         OutputStream outputStream = HttpMessageParser.parseHttpResponse(httpResponse);

--- a/src/test/java/webserver/RequestRouterTest.java
+++ b/src/test/java/webserver/RequestRouterTest.java
@@ -1,5 +1,6 @@
 package webserver;
 
+import db.Database;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -23,6 +24,7 @@ public class RequestRouterTest {
 
     @BeforeEach
     void setUp() {
+        Database.clear();
         requestRouter = new HttpRequestRouter();
     }
 

--- a/src/test/java/webserver/RequestRouterTest.java
+++ b/src/test/java/webserver/RequestRouterTest.java
@@ -31,7 +31,7 @@ public class RequestRouterTest {
     @DisplayName("정적 리소스에 대한 요청 처리 테스트")
     void routeStaticResource(String path, StatusCode expectedStatusCode, byte[] expectedBody) throws IOException, InvocationTargetException, IllegalAccessException {
         HttpRequest httpRequest = new HttpRequest(HttpMethod.GET,
-                new URI(path, Map.of(), "txt"),
+                new URI(path, Map.of(), MIME.TXT),
                 "HTTP/1.1",
                 new HashMap<>());
 

--- a/src/test/java/webserver/RequestRouterTest.java
+++ b/src/test/java/webserver/RequestRouterTest.java
@@ -1,6 +1,6 @@
 package webserver;
 
-import db.Database;
+import Application.db.Database;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;

--- a/src/test/java/webserver/RequestRouterTest.java
+++ b/src/test/java/webserver/RequestRouterTest.java
@@ -17,7 +17,6 @@ import java.util.stream.Stream;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-
 public class RequestRouterTest {
 
     HttpRequestRouter requestRouter;

--- a/src/test/java/webserver/RequestRouterTest.java
+++ b/src/test/java/webserver/RequestRouterTest.java
@@ -63,7 +63,7 @@ public class RequestRouterTest {
 
     public static Stream<Arguments> providePathAndParametersAndStatusCodeForTestingURIAndParameters() {
         return Stream.of(
-                Arguments.of("/user/create", Map.of("userId", "userId", "password", "password", "name", "name", "email", "email"), StatusCode.OK),
+                Arguments.of("/user/create", Map.of("userId", "userId", "password", "password", "name", "name", "email", "email"), StatusCode.FOUND),
                 Arguments.of("/nonexistent", Map.of("userId", "userId", "password", "password", "name", "name", "email", "email"), StatusCode.NOT_FOUND),
                 Arguments.of("/user/create", Map.of("password", "password", "name", "name", "email", "email"), StatusCode.BAD_REQUEST)
         );

--- a/src/test/java/webserver/StaticResourceHandlerTest.java
+++ b/src/test/java/webserver/StaticResourceHandlerTest.java
@@ -1,6 +1,6 @@
 package webserver;
 
-import exceptions.PathNotFoundException;
+import webserver.exceptions.PathNotFoundException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;

--- a/src/test/java/webserver/StaticResourceHandlerTest.java
+++ b/src/test/java/webserver/StaticResourceHandlerTest.java
@@ -4,8 +4,11 @@ import exceptions.PathNotFoundException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import webserver.handlers.StaticResourceHandler;
+import webserver.http.message.MIME;
+import webserver.http.message.URI;
 
 import java.io.IOException;
+import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -13,19 +16,21 @@ public class StaticResourceHandlerTest {
 
     @Test
     @DisplayName("존재하는 경로의 정적 리소스의 경우 바이트 파일을 반환한다.")
-    public void getStaticResourceExisting() throws IOException {
+    void getStaticResourceExisting() throws IOException {
         String resourcePath = "/exampleForTest.txt";
-        byte[] content = StaticResourceHandler.getStaticResource(resourcePath);
+        URI uri = new URI(resourcePath, Map.of(), MIME.TXT);
+        byte[] content = StaticResourceHandler.getResourceForTest(uri);
         assertNotNull(content);
         assertTrue(content.length > 0);
     }
 
     @Test
     @DisplayName("존재하지 않는 경로의 정적 리소스 요청은 PathNotFoundException을 발생시킨다.")
-    public void getStaticResourceNonExisting() {
+    void getStaticResourceNonExisting() {
         String resourcePath = "/non_existing.txt";
+        URI uri = new URI(resourcePath, Map.of(), MIME.TXT);
         assertThrows(PathNotFoundException.class, () -> {
-            StaticResourceHandler.getStaticResource(resourcePath);
+            StaticResourceHandler.getResourceForTest(uri);
         });
     }
 }


### PR DESCRIPTION
## 구현 내용
- 리다이렉트 기능 구현
- 요청 URI의 MIME 타입에 따른 처리 로직 구현
- 영속 계층 동시성 관련 버그 수정
- 어노테이션을 이용한 파라미터 검증 로직 구현

## 고민 사항
- 클래스 내부 필드가 Optional 타입을 갖는 것에 대해서 고민했다. URI의 쿼리와 확장자는 존재하지 않을 수 있는데 null을 사용하고 싶지 않기 때문이었다. 내가 판단한 Optional 사용했을 때의 장점은 존재하지 않을 수 있다는 의미를 확실하게 보여줄 수 있다는 점과, NPE 리스크가 없다는 점, 추가적인 처리가 필요 없다는 점이다. 반면에 사용했을 때 추가적인 오버헤드가 발생한다는 단점도 알게 되었다. 이 둘 사이를 잘 저울질해야할 것 같은데, 아직 결정하지 못했다.
- WAS의 역할이 무엇이고 이것을 달성하기 위해서 역할을 어떻게 분리해야할 지 고민했다. Application은 회원 관리, 게시판 관리를 포함하고 있어야 하며, 이 과정에서 WAS가 제공하는 방식에 의존하는 식이어야한다고 생각했다. 즉, 애플리케이션의 형태가 변하더라도 웹 서버는 일반적으로 적용될 수 있어야 한다는 것이다. 이 생각을 기준으로 기존에는 Application이 가지고 있었던 로직을 일부 분리했다.
  ex)  query parameter의 유효성 검증을 Application에 속하는 User 도메인이 가지고 있었고, 이를 해결하기 위해서 입력이 필수적인 매개변수를 어노테이션을 이용해서 확인하는 로직을 추가했다. 

## 기타
- 응답 메세지의 헤더와 바디를 채우는 로직이 여러 개 존재하면서, 일관성 없이 작성된 것 같다. (정적인 리소스에 대한 요청과, Controller를 통한 요청 등) 이 부분을 분리해내고 추상화할 필요가 있을 것 같은데 아직 해결하지 못했다.