### PR TITLE
[조형준] step-3 다양한 컨텐츠 타입 지원

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.8.1'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.1'
     testImplementation 'org.assertj:assertj-core:3.16.1'
+    testImplementation 'io.rest-assured:rest-assured:5.3.1'
 
 }
 

--- a/src/main/java/controller/SignUpController.java
+++ b/src/main/java/controller/SignUpController.java
@@ -2,6 +2,7 @@ package controller;
 
 import db.Database;
 import model.User;
+import webserver.exception.BadRequestException;
 import webserver.reponse.HttpResponse;
 import webserver.request.HttpRequest;
 
@@ -17,7 +18,10 @@ public class SignUpController implements Controller {
 
     @Override
     public void verifyRequest(HttpRequest request){
-
+        if(request.getParamValueByKey("userId") == null || request.getParamValueByKey("password") == null ||
+                request.getParamValueByKey("name") == null || request.getParamValueByKey("email") == null) {
+            throw new BadRequestException();
+        }
     }
 
     @Override

--- a/src/main/java/utils/StaticFIleUtils.java
+++ b/src/main/java/utils/StaticFIleUtils.java
@@ -19,11 +19,11 @@ public class StaticFIleUtils {
     }
 
     public static void getStaticByte(String url, HttpResponse response) throws IOException {
+        String[] urlParts = url.split("[.]");
         if(Files.exists(new File("src/main/resources/templates" + url).toPath())){
-            response.setBodyByFile(Files.readAllBytes(new File("src/main/resources/templates" + url).toPath()), Type.HTML);
+            response.setBodyByFile(Files.readAllBytes(new File("src/main/resources/templates" + url).toPath()), Type.getType(urlParts[urlParts.length-1]));
             return;
         }
-        String[] urlParts = url.split("[.]");
-        response.setBodyByFile(Files.readAllBytes(new File("src/main/resources/static" + url).toPath()),Type.getType(url.split("[.]")[urlParts.length-1]));
+        response.setBodyByFile(Files.readAllBytes(new File("src/main/resources/static" + url).toPath()),Type.getType(urlParts[urlParts.length-1]));
     }
 }

--- a/src/main/java/webserver/FrontController.java
+++ b/src/main/java/webserver/FrontController.java
@@ -11,11 +11,9 @@ import webserver.request.HttpRequest;
 import java.io.IOException;
 
 public class FrontController {
-    //TODO 정적파일 요청인지 api 요청인지 확인 후 그에 따른 로직 처리
 
     public static void service(HttpRequest request, HttpResponse response) throws IOException {
         if(StaticFIleUtils.isExistedStaticFileRequest(request.getUrl())) {
-            //TODO response에 정적 파일 제공, content-type 제공
             StaticFIleUtils.getStaticByte(request.getUrl(), response);
             return;
         }

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -27,15 +27,12 @@ public class RequestHandler implements Runnable {//함수형 인터페이스
                 connection.getPort());
         HttpResponse response = new HttpResponse();
         try (InputStream in = connection.getInputStream(); OutputStream out = connection.getOutputStream()) {
-            if(in == null) {
+            if(in.readAllBytes() == null) {
                 return;
             }
-            //1.리퀘스트를 파싱해서 그에 대한 정보를 분석하자! -> inputStream을 받아서 찍어보기
             HttpRequest request = HttpRequestParser.getRequest(in);
             logger.debug("Request Header : \n{}", request.getHeader());
 
-            //2.리퀘스트의 method와 url을 분석해 컨트롤러 매핑 후 정적 파일을 보내주도록 하자!
-            // TODO 사용자 요청에 대한 처리는 이 곳에 구현하면 된다.
             process(request, response);
             DataOutputStream dos = new DataOutputStream(out);
             responseHeader(dos, response);

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -31,7 +31,7 @@ public class RequestHandler implements Runnable {//함수형 인터페이스
                 return;
             }
             //1.리퀘스트를 파싱해서 그에 대한 정보를 분석하자! -> inputStream을 받아서 찍어보기
-            HttpRequest request = HttpRequestParser.getInstance().getRequest(in);
+            HttpRequest request = HttpRequestParser.getRequest(in);
             logger.debug("Request Header : \n{}", request.getHeader());
 
             //2.리퀘스트의 method와 url을 분석해 컨트롤러 매핑 후 정적 파일을 보내주도록 하자!

--- a/src/main/java/webserver/reponse/HttpResponse.java
+++ b/src/main/java/webserver/reponse/HttpResponse.java
@@ -23,8 +23,8 @@ public class HttpResponse {
 
     public void setBodyByText(String body) {
         this.body = body.getBytes();
-        setHeader("Content-Type", Type.TEXT.getContentType());
         setHeader("Content-Length", String.valueOf(this.body.length));
+        setHeader("Content-Type", Type.TEXT.getContentType());
     }
 
     public void setHeader(String key, String value){

--- a/src/main/java/webserver/reponse/Type.java
+++ b/src/main/java/webserver/reponse/Type.java
@@ -37,6 +37,10 @@ public enum Type {
                 return PNG;
             case "ico":
                 return ICO;
+            case "txt":
+                return TEXT;
+            case "html":
+                return HTML;
             default:
                 return null;
         }

--- a/src/main/java/webserver/request/HttpRequestParser.java
+++ b/src/main/java/webserver/request/HttpRequestParser.java
@@ -11,22 +11,17 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class HttpRequestParser {
-    private static final HttpRequestParser requestParser = new HttpRequestParser();
     private HttpRequestParser() {
 
     }
 
-    public static HttpRequestParser getInstance() {
-        return requestParser;
-    }
-
-    public HttpRequest getRequest(InputStream in) throws  IOException{
+    public static HttpRequest getRequest(InputStream in) throws  IOException{
         BufferedReader br = new BufferedReader(new InputStreamReader(in));
 
         return parseRequest(br);
     }
 
-    private HttpRequest parseRequest(BufferedReader br) throws IOException {
+    private static HttpRequest parseRequest(BufferedReader br) throws IOException {
         if(!br.ready()){
             return new HttpRequest();
         }
@@ -36,7 +31,7 @@ public class HttpRequestParser {
 
     }
 
-    private Map<String, String> initParams(String line) {
+    private static Map<String, String> initParams(String line) {
         String[] params = line.split("[?]");
         Map<String, String> paramsMap = new HashMap<>();
         if(params.length > 1){
@@ -48,7 +43,7 @@ public class HttpRequestParser {
         return paramsMap;
     }
 
-    private String initHeader(BufferedReader br, String line) throws IOException {
+    private static String initHeader(BufferedReader br, String line) throws IOException {
         StringBuilder headerBuilder = new StringBuilder();
         while (line != null && !line.equals("")) {
             headerBuilder.append(StringUtils.appendLineSeparator(line));
@@ -57,7 +52,7 @@ public class HttpRequestParser {
         return headerBuilder.toString();
     }
 
-    private String initBody(BufferedReader br) throws IOException {
+    private static String initBody(BufferedReader br) throws IOException {
         StringBuilder bodyBuilder = new StringBuilder();
         while (br.ready()){
             bodyBuilder.append((char)br.read());

--- a/src/test/java/controller/SignUpControllerTest.java
+++ b/src/test/java/controller/SignUpControllerTest.java
@@ -25,7 +25,7 @@ class SignUpControllerTest {
     @BeforeEach
     void init() throws IOException {
         signUpController = new SignUpController();
-        request= HttpRequestParser.getInstance().getRequest(new ByteArrayInputStream(("GET /user/create?userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net HTTP/1.1\n" +
+        request= HttpRequestParser.getRequest(new ByteArrayInputStream(("GET /user/create?userId=javajigi&password=password&name=%EB%B0%95%EC%9E%AC%EC%84%B1&email=javajigi%40slipp.net HTTP/1.1\n" +
                 "Host: localhost:8080\n" +
                 "Connection: keep-alive\n" +
                 "Accept: */*").getBytes()));

--- a/src/test/java/webserver/FrontControllerTest.java
+++ b/src/test/java/webserver/FrontControllerTest.java
@@ -1,0 +1,54 @@
+package webserver;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import webserver.exception.BadRequestException;
+import webserver.exception.NotFoundException;
+import webserver.reponse.HttpResponse;
+import webserver.request.HttpRequest;
+import webserver.request.HttpRequestParser;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class FrontControllerTest {
+
+    String badRequestInput = "GET /user/create?id=1&password=1234 HTTP/1.1\n" +
+            "Host: localhost:8080\n" +
+            "Connection: keep-alive\n" +
+            "sec-ch-ua: \"Not.A/Brand\";v=\"8\", \"Chromium\";v=\"114\", \"Google Chrome\";v=\"114\"\n" +
+            "sec-ch-ua-mobile: ?0\n" +
+            "User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36\n" +
+            "sec-ch-ua-platform: \"macOS\"\n" +
+            "Accept: image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8\n" +
+            "Sec-Fetch-Site: same-origin\n" +
+            "Sec-Fetch-Mode: no-cors\n" +
+            "Sec-Fetch-Dest: image\n" +
+            "Referer: http://localhost:8080/\n" +
+            "Accept-Encoding: gzip, deflate, br\n" +
+            "Accept-Language: ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7\n" +
+            "\n" +
+            "{\n" +
+            "  \"name\": \"John Doe\",\n" +
+            "  \"email\": \"john@example.com\",\n" +
+            "  \"age\": 30\n" +
+            "}\n";
+    @Test
+    @DisplayName("요청과 일치하는 method나 url이 없으면 NotFoundException 반환한다.")
+    void NotFoundException() {
+        HttpRequest request = new HttpRequest("GET", "/index.qwer", null, null, null);
+        HttpResponse response = new HttpResponse();
+        assertThrows(NotFoundException.class, () -> FrontController.service(request, response));
+    }
+
+    @Test
+    @DisplayName("컨트롤러에서 요구하는 요청 값이 제대로 들어있지 않을 경우 BadRequestException을 반환한다.")
+    void BadRequestException() throws IOException {
+        HttpRequest request = HttpRequestParser.getRequest(new ByteArrayInputStream(badRequestInput.getBytes()));
+        HttpResponse response = new HttpResponse();
+        assertThrows(BadRequestException.class, () -> FrontController.service(request, response));
+    }
+
+}

--- a/src/test/java/webserver/RequestHandlerTest.java
+++ b/src/test/java/webserver/RequestHandlerTest.java
@@ -1,0 +1,7 @@
+package webserver;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class RequestHandlerTest {
+
+}

--- a/src/test/java/webserver/RequestHandlerTest.java
+++ b/src/test/java/webserver/RequestHandlerTest.java
@@ -1,7 +1,85 @@
 package webserver;
 
+import db.Database;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import org.apache.groovy.json.internal.IO;
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import webserver.reponse.HttpResponse;
+import webserver.reponse.HttpResponseStatus;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.Arrays;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 class RequestHandlerTest {
+
+    @Test
+    @DisplayName("localhost:8080/index.html로 get 요청이 들어오면 index.html 파일을 반환해야 한다.")
+    void indexHtml() throws IOException {
+        assertTrue(Arrays.equals(RestAssured.get("/index.html")
+                .getBody()
+                .asByteArray(), Files.readAllBytes(new File("src/main/resources/templates/index.html").toPath())));
+    }
+
+    @Test
+    @DisplayName("localhost:8080/styles.css로 get 요청이 들어오면 styles.css 파일을 반환해야 한다.")
+    void stylesCss() throws IOException {
+        Arrays.equals(RestAssured.get("/styles.css")
+                .getBody()
+                .asByteArray(), Files.readAllBytes(new File("src/main/resources/static/css/styles.css").toPath()));
+    }
+
+    @Test
+    @DisplayName("localhost:8080/user/create로 적절한 파라미터와 함께 get 요청이 들어오면 로그인 처리를 하고 status 200을 반환해야 한다.")
+    void createUser() throws IOException {
+
+        RestAssured
+                .given()
+                    .param("userId", "id")
+                    .param("password", "password")
+                    .param("email", "email")
+                    .param("name", "name")
+                .when()
+                    .get("/user/create")
+                .then()
+                    .assertThat()
+                    .statusCode(HttpStatus.SC_OK)
+                    .contentType(ContentType.TEXT);
+    }
+
+    @Test
+    @DisplayName("localhost:8080/user/create로 get 요청시 파라미터가 제대로 들어있지 않다면 400에러를 반환해야 한다.")
+    void createUserBadRequest() throws IOException {
+        RestAssured
+                .given()
+                    .param("userId", "id")
+                    .param("password", "password")
+                    .param("email", "email")
+                .when()
+                    .get("/user/create")
+                .then()
+                    .assertThat()
+                    .statusCode(HttpStatus.SC_BAD_REQUEST)
+                    .contentType(ContentType.TEXT);
+    }
+
+    @Test
+    @DisplayName("일치하는 메소드와 url을 처리할 controller가 없을 시 404 not found를 반환한다.")
+    void NotFound() throws IOException {
+        RestAssured
+                .when()
+                    .get("/abc/abc")
+                .then()
+                    .assertThat()
+                    .statusCode(HttpStatus.SC_NOT_FOUND)
+                    .contentType(ContentType.TEXT);
+    }
+
 
 }

--- a/src/test/java/webserver/reponse/HttpResponseTest.java
+++ b/src/test/java/webserver/reponse/HttpResponseTest.java
@@ -1,14 +1,32 @@
 package webserver.reponse;
 
+import io.restassured.RestAssured;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import io.restassured.RestAssured.*;
+import io.restassured.matcher.RestAssuredMatchers.*;
+import org.hamcrest.Matchers.*;
 
 import static org.junit.jupiter.api.Assertions.*;
 
 class HttpResponseTest {
-    @Test
-    @DisplayName("")
-    void header(){
 
+    HttpResponse httpResponse;
+
+    @BeforeEach
+    void init() {
+        httpResponse = new HttpResponse();
+    }
+
+    @Test
+    @DisplayName("response 헤더명과 헤더값을 넣으면 이를 key, value 쌍으로 저장해야 한다.")
+    void header() {
+        httpResponse.setStatus(HttpResponseStatus.STATUS_200);
+        httpResponse.setHeader("Host", "localhost:8080");
+        httpResponse.setHeader("Connection", "keep-alive");
+        httpResponse.setHeader("sec-ch-ua", "\"Not.A/Brand\";v=\"8\", \"Chromium\";v=\"114\", \"Google Chrome\";v=\"114\"");
+        httpResponse.setHeader("sec-ch-ua-mobile", "?0");
+        httpResponse.setHeader("User-Agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36");
     }
 }

--- a/src/test/java/webserver/reponse/HttpResponseTest.java
+++ b/src/test/java/webserver/reponse/HttpResponseTest.java
@@ -8,11 +8,20 @@ import io.restassured.RestAssured.*;
 import io.restassured.matcher.RestAssuredMatchers.*;
 import org.hamcrest.Matchers.*;
 
+import java.util.Arrays;
+
 import static org.junit.jupiter.api.Assertions.*;
 
 class HttpResponseTest {
 
     HttpResponse httpResponse;
+
+    String header = "HTTP/1.1 200 OK\r\n" +
+            "Host: localhost:8080\r\n";
+
+    String headerWithContent = "HTTP/1.1 200 OK\r\n" +
+            "Content-Type: text/plain;charset=utf-8\r\n" +
+            "Content-Length: 11\r\n";
 
     @BeforeEach
     void init() {
@@ -24,9 +33,17 @@ class HttpResponseTest {
     void header() {
         httpResponse.setStatus(HttpResponseStatus.STATUS_200);
         httpResponse.setHeader("Host", "localhost:8080");
-        httpResponse.setHeader("Connection", "keep-alive");
-        httpResponse.setHeader("sec-ch-ua", "\"Not.A/Brand\";v=\"8\", \"Chromium\";v=\"114\", \"Google Chrome\";v=\"114\"");
-        httpResponse.setHeader("sec-ch-ua-mobile", "?0");
-        httpResponse.setHeader("User-Agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36");
+
+        assertEquals(header, httpResponse.getHttpResponseHeader());
+    }
+
+    @Test
+    @DisplayName("response에 body값을 넣으면 body를 byte[] 형태로 저장하고 그에 맞는 타입과 길이를 헤어데 저장해야 한다.")
+    void body(){
+        httpResponse.setStatus(HttpResponseStatus.STATUS_200);
+        httpResponse.setBodyByText("Hello World");
+
+        assertTrue(Arrays.equals("Hello World".getBytes(), httpResponse.getHttpResponseBody()));
+        assertEquals(headerWithContent, httpResponse.getHttpResponseHeader());
     }
 }

--- a/src/test/java/webserver/reponse/HttpResponseTest.java
+++ b/src/test/java/webserver/reponse/HttpResponseTest.java
@@ -1,0 +1,14 @@
+package webserver.reponse;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class HttpResponseTest {
+    @Test
+    @DisplayName("")
+    void header(){
+
+    }
+}

--- a/src/test/java/webserver/reponse/HttpResponseTest.java
+++ b/src/test/java/webserver/reponse/HttpResponseTest.java
@@ -4,9 +4,6 @@ import io.restassured.RestAssured;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import io.restassured.RestAssured.*;
-import io.restassured.matcher.RestAssuredMatchers.*;
-import org.hamcrest.Matchers.*;
 
 import java.util.Arrays;
 
@@ -20,9 +17,8 @@ class HttpResponseTest {
             "Host: localhost:8080\r\n";
 
     String headerWithContent = "HTTP/1.1 200 OK\r\n" +
-            "Content-Type: text/plain;charset=utf-8\r\n" +
-            "Content-Length: 11\r\n";
-
+            "Content-Length: 11\r\n" +
+            "Content-Type: text/plain;charset=utf-8\r\n";
     @BeforeEach
     void init() {
         httpResponse = new HttpResponse();

--- a/src/test/java/webserver/reponse/TypeTest.java
+++ b/src/test/java/webserver/reponse/TypeTest.java
@@ -1,0 +1,27 @@
+package webserver.reponse;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class TypeTest {
+
+    @Test
+    @DisplayName("file 형식에에 맞는 Content-Type을 반환해야 한다.")
+    void getTypeTest (){
+        verifyGetType("css", Type.CSS);
+        verifyGetType("txt", Type.TEXT);
+        verifyGetType("html", Type.HTML);
+        verifyGetType("xml", Type.XML);
+        verifyGetType("js", Type.JS);
+        verifyGetType("ttf", Type.TTF);
+        verifyGetType("png", Type.PNG);
+        verifyGetType("eot", Type.EOT);
+    }
+
+    void verifyGetType(String contentType, Type type) {
+        assertEquals(Type.getType(contentType), type);
+    }
+
+}

--- a/src/test/java/webserver/request/HttpRequestMapperTest.java
+++ b/src/test/java/webserver/request/HttpRequestMapperTest.java
@@ -1,8 +1,9 @@
-package webserver;
+package webserver.request;
 
 import controller.SignUpController;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import webserver.HttpRequestMapper;
 import webserver.request.HttpRequest;
 import webserver.request.HttpRequestParser;
 
@@ -21,7 +22,7 @@ class HttpRequestMapperTest {
     }
 
     void verifyController(String statusLine, Class clazz) throws IOException {
-        HttpRequest request = HttpRequestParser.getInstance().getRequest(new ByteArrayInputStream(statusLine.getBytes()));
+        HttpRequest request = HttpRequestParser.getRequest(new ByteArrayInputStream(statusLine.getBytes()));
         assertInstanceOf(clazz, HttpRequestMapper.getInstance().getController(request.getMethod(),request.getUrl()));
     }
 }

--- a/src/test/java/webserver/request/HttpRequestParserTest.java
+++ b/src/test/java/webserver/request/HttpRequestParserTest.java
@@ -1,4 +1,4 @@
-package webserver;
+package webserver.request;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -59,7 +59,7 @@ class HttpRequestParserTest {
 
     @BeforeEach
     void init() throws IOException{
-        request = HttpRequestParser.getInstance().getRequest(new ByteArrayInputStream(requestInput.getBytes()));
+        request = HttpRequestParser.getRequest(new ByteArrayInputStream(requestInput.getBytes()));
     }
 
 


### PR DESCRIPTION
## 구현 내용
html 파일을 제외한 css,js,ttf 등 다양한 타입의 파일 지원
각 타입에 맞는 content-type 지정
단위 테스트 작성
## 고민 사항
테스트 코드를 어느식으로 짜야 하는지 감이 잘 잡히지 않았다. 같은 팀원 분이 추천해주신 rest-assured를 사용하여 http 요청을 날려 단위 테스트를 손 쉽게 할 수 있었다. 다만 이를 이용해서 post 요청을 할 때 요청이 제대로 감지되지 않는 경향이 있어 자세히 알아보도록 해야겠다.
