### PR TITLE
[정성태] step-6 동적인 HTML

### DIFF
--- a/src/main/java/controller/FileController.java
+++ b/src/main/java/controller/FileController.java
@@ -1,7 +1,9 @@
 package controller;
 
 import http.HttpUtil;
+import model.User;
 import service.FileService;
+import service.UserService;
 import webserver.model.Request;
 import webserver.model.Response;
 
@@ -23,6 +25,8 @@ public class FileController {
     private static final String BUTTON_LOGIN = "<li><a href=\"user/login.html\" role=\"button\">로그인</a></li>";
     private static final String BUTTON_SIGNUP = "<li><a href=\"user/form.html\" role=\"button\">회원가입</a></li>";
     private static final String BUTTON_MODIFY_USERDATA = "<li><a href=\"#\" role=\"button\">개인정보수정</a></li>";
+    private static final String USER_LIST_TBODY = "<tbody>";
+    private static final String USER_LIST_ROW_FORM = "<tr>\n<th scope=\"row\">%d</th> <td>%s</td> <td>%s</td> <td>%s</td><td><a href=\"#\" class=\"btn btn-success\" role=\"button\">수정</a></td>\n</tr>";
 
     public static Response genereateResponse(Request request) throws IOException {
         String targetUri = request.getTargetUri();
@@ -45,6 +49,8 @@ public class FileController {
         if(new File(targetPath).exists()) {
             String sid = request.getSid();
             String httpDocument = new String(readStaticFile(TEMPLATE_FILEPATH + targetUri));
+
+            // Navbar
             if(sid == null) {
                 httpDocument = httpDocument.replace(BUTTON_LOGOUT, "");
                 httpDocument = httpDocument.replace(BUTTON_MODIFY_USERDATA, "");
@@ -54,6 +60,20 @@ public class FileController {
                         String.format(USERNAME_FORMAT, getUserIdBySid(sid)));
                 httpDocument = httpDocument.replace(BUTTON_LOGIN, "");
                 httpDocument = httpDocument.replace(BUTTON_SIGNUP, "");
+            }
+
+            // userList
+            if(targetUri.equals("/user/list.html")) {
+                if(sid != null) {
+                    StringBuilder sb = new StringBuilder();
+                    int i = 0;
+                    for(User user: UserService.getAllUser()) {
+                        i++;
+                        String tr = String.format(USER_LIST_ROW_FORM, i, user.getUserId(), user.getName(), user.getEmail());
+                        sb.append(tr);
+                    }
+                    httpDocument = httpDocument.replace(USER_LIST_TBODY, USER_LIST_TBODY + sb);
+                }
             }
             body = httpDocument.getBytes();
         }

--- a/src/main/java/controller/FileController.java
+++ b/src/main/java/controller/FileController.java
@@ -54,13 +54,13 @@ public class FileController {
 
             // Navbar
             if(sid == null) {
-                httpDocument = httpDocument.replaceAll(BUTTON_LOGOUT, "");
-                httpDocument = httpDocument.replaceAll(BUTTON_MODIFY_USERDATA, "");
+                httpDocument = removeElement(httpDocument, BUTTON_LOGOUT);
+                httpDocument = removeElement(httpDocument, BUTTON_MODIFY_USERDATA);
             }
             else {
-                httpDocument = appendTail(httpDocument, NAVBAR_RIGHT, String.format(USERNAME_FORMAT, getUserIdBySid(sid)));
-                httpDocument = httpDocument.replaceAll(BUTTON_LOGIN, "");
-                httpDocument = httpDocument.replaceAll(BUTTON_SIGNUP, "");
+                httpDocument = appendElement(httpDocument, NAVBAR_RIGHT, String.format(USERNAME_FORMAT, getUserIdBySid(sid)));
+                httpDocument = removeElement(httpDocument, BUTTON_LOGIN);
+                httpDocument = removeElement(httpDocument, BUTTON_SIGNUP);
             }
 
             // userList
@@ -73,7 +73,7 @@ public class FileController {
                         String tr = String.format(USER_LIST_ROW_FORM, i, user.getUserId(), user.getName(), user.getEmail());
                         sb.append(tr);
                     }
-                    httpDocument = appendTail(httpDocument, USER_LIST_TBODY, sb.toString());
+                    httpDocument = appendElement(httpDocument, USER_LIST_TBODY, sb.toString());
                 }
             }
             body = httpDocument.getBytes();
@@ -86,7 +86,13 @@ public class FileController {
         return new Response(STATUS.OK, headerMap, body);
     }
 
-    private static String appendTail(String source, String regex, String tail) {
+    private static String removeElement(String source, String regex) {
+        source = source.replaceAll(regex, "");
+
+        return source;
+    }
+
+    private static String appendElement(String source, String regex, String tail) {
         Pattern pattern = Pattern.compile(regex);
         Matcher matcher = pattern.matcher(source);
 

--- a/src/main/java/controller/FileController.java
+++ b/src/main/java/controller/FileController.java
@@ -65,7 +65,12 @@ public class FileController {
 
             // userList
             if(targetUri.equals(USER_LIST_URL)) {
-                if(sid != null) {
+                if(sid == null) {
+                    Map<String, String> headerMap = new HashMap<>();
+                    headerMap.put(HEADER_REDIRECT_LOCATION, INDEX_URL);
+                    return new Response(STATUS.SEE_OTHER, headerMap, null);
+                }
+                else {
                     StringBuilder sb = new StringBuilder();
                     int i = 0;
                     for(User user: UserService.getAllUser()) {

--- a/src/main/java/controller/FileController.java
+++ b/src/main/java/controller/FileController.java
@@ -64,7 +64,7 @@ public class FileController {
             }
 
             // userList
-            if(targetUri.equals("/user/list.html")) {
+            if(targetUri.equals(USER_LIST_URL)) {
                 if(sid != null) {
                     StringBuilder sb = new StringBuilder();
                     int i = 0;
@@ -76,6 +76,7 @@ public class FileController {
                     httpDocument = appendElement(httpDocument, USER_LIST_TBODY, sb.toString());
                 }
             }
+
             body = httpDocument.getBytes();
         }
 

--- a/src/main/java/controller/FileController.java
+++ b/src/main/java/controller/FileController.java
@@ -22,8 +22,8 @@ public class FileController {
     private static final String NAVBAR_RIGHT = "/user/list.html\"><i class=\"glyphicon glyphicon-user\"></i></a></li>";
     private static final String USERNAME_FORMAT = "<li>%s</li>";
     private static final String BUTTON_LOGOUT = "<li><a href=\"#\" role=\"button\">로그아웃</a></li>";
-    private static final String BUTTON_LOGIN = "<li><a href=\"user/login.html\" role=\"button\">로그인</a></li>";
-    private static final String BUTTON_SIGNUP = "<li><a href=\"user/form.html\" role=\"button\">회원가입</a></li>";
+    private static final String BUTTON_LOGIN = "user/login.html\" role=\"button\">로그인</a></li>";
+    private static final String BUTTON_SIGNUP = "user/form.html\" role=\"button\">회원가입</a></li>";
     private static final String BUTTON_MODIFY_USERDATA = "<li><a href=\"#\" role=\"button\">개인정보수정</a></li>";
     private static final String USER_LIST_TBODY = "<tbody>";
     private static final String USER_LIST_ROW_FORM = "<tr>\n<th scope=\"row\">%d</th> <td>%s</td> <td>%s</td> <td>%s</td><td><a href=\"#\" class=\"btn btn-success\" role=\"button\">수정</a></td>\n</tr>";

--- a/src/main/java/controller/FileController.java
+++ b/src/main/java/controller/FileController.java
@@ -19,7 +19,7 @@ import static service.SessionService.getUserIdBySid;
 public class FileController {
     private static final String STATIC_FILEPATH = "./src/main/resources/static";
     private static final String TEMPLATE_FILEPATH = "./src/main/resources/templates";
-    private static final String NAVBAR_RIGHT = "<li><a href=\"./user/list.html\"><i class=\"glyphicon glyphicon-user\"></i></a></li>";
+    private static final String NAVBAR_RIGHT = "/user/list.html\"><i class=\"glyphicon glyphicon-user\"></i></a></li>";
     private static final String USERNAME_FORMAT = "<li>%s</li>";
     private static final String BUTTON_LOGOUT = "<li><a href=\"#\" role=\"button\">로그아웃</a></li>";
     private static final String BUTTON_LOGIN = "<li><a href=\"user/login.html\" role=\"button\">로그인</a></li>";

--- a/src/main/java/controller/FileController.java
+++ b/src/main/java/controller/FileController.java
@@ -20,7 +20,7 @@ public class FileController {
         String extension = tokens[tokens.length-1];
         HttpUtil.MIME mime = HttpUtil.MIME.getMimeByExtension(extension);
         if (mime != null) {
-            byte[] body = FileService.loadStaticFile(targetUri);
+            byte[] body = FileService.loadFile(request);
 
             Map<String, String> headerMap = new HashMap<>();
             headerMap.put(HEADER_CONTENT_TYPE, mime.getMime() + HEADER_CHARSET);

--- a/src/main/java/controller/FileController.java
+++ b/src/main/java/controller/FileController.java
@@ -73,7 +73,7 @@ public class FileController {
                         String tr = String.format(USER_LIST_ROW_FORM, i, user.getUserId(), user.getName(), user.getEmail());
                         sb.append(tr);
                     }
-                    httpDocument = httpDocument.replaceAll(USER_LIST_TBODY, USER_LIST_TBODY + sb);
+                    httpDocument = appendTail(httpDocument, USER_LIST_TBODY, sb.toString());
                 }
             }
             body = httpDocument.getBytes();

--- a/src/main/java/controller/FileController.java
+++ b/src/main/java/controller/FileController.java
@@ -5,13 +5,25 @@ import service.FileService;
 import webserver.model.Request;
 import webserver.model.Response;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
 import static http.HttpUtil.*;
+import static service.FileService.readStaticFile;
+import static service.SessionService.getUserIdBySid;
 
 public class FileController {
+    private static final String STATIC_FILEPATH = "./src/main/resources/static";
+    private static final String TEMPLATE_FILEPATH = "./src/main/resources/templates";
+    private static final String NAVBAR_RIGHT = "<li><a href=\"./user/list.html\"><i class=\"glyphicon glyphicon-user\"></i></a></li>";
+    private static final String USERNAME_FORMAT = "<li>%s</li>";
+    private static final String BUTTON_LOGOUT = "<li><a href=\"#\" role=\"button\">로그아웃</a></li>";
+    private static final String BUTTON_LOGIN = "<li><a href=\"user/login.html\" role=\"button\">로그인</a></li>";
+    private static final String BUTTON_SIGNUP = "<li><a href=\"user/form.html\" role=\"button\">회원가입</a></li>";
+    private static final String BUTTON_MODIFY_USERDATA = "<li><a href=\"#\" role=\"button\">개인정보수정</a></li>";
+
     public static Response genereateResponse(Request request) throws IOException {
         String targetUri = request.getTargetUri();
 
@@ -19,16 +31,37 @@ public class FileController {
         String[] tokens = targetUri.split("\\.");
         String extension = tokens[tokens.length-1];
         HttpUtil.MIME mime = HttpUtil.MIME.getMimeByExtension(extension);
-        if (mime != null) {
-            byte[] body = FileService.loadFile(request);
+        if(mime == null) {
+            return null;
+        }
+        String targetPath;
+        byte[] body = null;
 
-            Map<String, String> headerMap = new HashMap<>();
-            headerMap.put(HEADER_CONTENT_TYPE, mime.getMime() + HEADER_CHARSET);
-            headerMap.put(HEADER_CONTENT_LENGTH, String.valueOf(body.length));
-
-            return new Response(STATUS.OK, headerMap, body);
+        targetPath = STATIC_FILEPATH + targetUri;
+        if(new File(targetPath).exists()) {
+            body = readStaticFile(targetPath);
+        }
+        targetPath = TEMPLATE_FILEPATH + targetUri;
+        if(new File(targetPath).exists()) {
+            String sid = request.getSid();
+            String httpDocument = new String(readStaticFile(TEMPLATE_FILEPATH + targetUri));
+            if(sid == null) {
+                httpDocument = httpDocument.replace(BUTTON_LOGOUT, "");
+                httpDocument = httpDocument.replace(BUTTON_MODIFY_USERDATA, "");
+            }
+            else {
+                httpDocument = httpDocument.replace(NAVBAR_RIGHT, NAVBAR_RIGHT +
+                        String.format(USERNAME_FORMAT, getUserIdBySid(sid)));
+                httpDocument = httpDocument.replace(BUTTON_LOGIN, "");
+                httpDocument = httpDocument.replace(BUTTON_SIGNUP, "");
+            }
+            body = httpDocument.getBytes();
         }
 
-        return null;
+        Map<String, String> headerMap = new HashMap<>();
+        headerMap.put(HEADER_CONTENT_TYPE, mime.getMime() + HEADER_CHARSET);
+        headerMap.put(HEADER_CONTENT_LENGTH, String.valueOf(body.length));
+
+        return new Response(STATUS.OK, headerMap, body);
     }
 }

--- a/src/main/java/controller/FileController.java
+++ b/src/main/java/controller/FileController.java
@@ -11,6 +11,8 @@ import java.io.File;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static http.HttpUtil.*;
 import static service.FileService.readStaticFile;
@@ -19,12 +21,12 @@ import static service.SessionService.getUserIdBySid;
 public class FileController {
     private static final String STATIC_FILEPATH = "./src/main/resources/static";
     private static final String TEMPLATE_FILEPATH = "./src/main/resources/templates";
-    private static final String NAVBAR_RIGHT = "/user/list.html\"><i class=\"glyphicon glyphicon-user\"></i></a></li>";
+    private static final String NAVBAR_RIGHT = "<li>.*?/user/list\\.html.*?</li>";
     private static final String USERNAME_FORMAT = "<li>%s</li>";
-    private static final String BUTTON_LOGOUT = "<li><a href=\"#\" role=\"button\">로그아웃</a></li>";
-    private static final String BUTTON_LOGIN = "user/login.html\" role=\"button\">로그인</a></li>";
-    private static final String BUTTON_SIGNUP = "user/form.html\" role=\"button\">회원가입</a></li>";
-    private static final String BUTTON_MODIFY_USERDATA = "<li><a href=\"#\" role=\"button\">개인정보수정</a></li>";
+    private static final String BUTTON_LOGOUT = "<li>.*?로그아웃.*?</li>";
+    private static final String BUTTON_LOGIN = "<li>.*?로그인.*?</li>";
+    private static final String BUTTON_SIGNUP = "<li>.*?회원가입.*?</li>";
+    private static final String BUTTON_MODIFY_USERDATA = "<li>.*?개인정보수정.*?</li>";
     private static final String USER_LIST_TBODY = "<tbody>";
     private static final String USER_LIST_ROW_FORM = "<tr>\n<th scope=\"row\">%d</th> <td>%s</td> <td>%s</td> <td>%s</td><td><a href=\"#\" class=\"btn btn-success\" role=\"button\">수정</a></td>\n</tr>";
 
@@ -52,14 +54,13 @@ public class FileController {
 
             // Navbar
             if(sid == null) {
-                httpDocument = httpDocument.replace(BUTTON_LOGOUT, "");
-                httpDocument = httpDocument.replace(BUTTON_MODIFY_USERDATA, "");
+                httpDocument = httpDocument.replaceAll(BUTTON_LOGOUT, "");
+                httpDocument = httpDocument.replaceAll(BUTTON_MODIFY_USERDATA, "");
             }
             else {
-                httpDocument = httpDocument.replace(NAVBAR_RIGHT, NAVBAR_RIGHT +
-                        String.format(USERNAME_FORMAT, getUserIdBySid(sid)));
-                httpDocument = httpDocument.replace(BUTTON_LOGIN, "");
-                httpDocument = httpDocument.replace(BUTTON_SIGNUP, "");
+                httpDocument = appendTail(httpDocument, NAVBAR_RIGHT, String.format(USERNAME_FORMAT, getUserIdBySid(sid)));
+                httpDocument = httpDocument.replaceAll(BUTTON_LOGIN, "");
+                httpDocument = httpDocument.replaceAll(BUTTON_SIGNUP, "");
             }
 
             // userList
@@ -72,7 +73,7 @@ public class FileController {
                         String tr = String.format(USER_LIST_ROW_FORM, i, user.getUserId(), user.getName(), user.getEmail());
                         sb.append(tr);
                     }
-                    httpDocument = httpDocument.replace(USER_LIST_TBODY, USER_LIST_TBODY + sb);
+                    httpDocument = httpDocument.replaceAll(USER_LIST_TBODY, USER_LIST_TBODY + sb);
                 }
             }
             body = httpDocument.getBytes();
@@ -83,5 +84,17 @@ public class FileController {
         headerMap.put(HEADER_CONTENT_LENGTH, String.valueOf(body.length));
 
         return new Response(STATUS.OK, headerMap, body);
+    }
+
+    private static String appendTail(String source, String regex, String tail) {
+        Pattern pattern = Pattern.compile(regex);
+        Matcher matcher = pattern.matcher(source);
+
+        while(matcher.find()) {
+            String foundString = matcher.group();
+            source = source.replaceAll(regex, foundString + tail);
+        }
+
+        return source;
     }
 }

--- a/src/main/java/controller/ServiceController.java
+++ b/src/main/java/controller/ServiceController.java
@@ -40,7 +40,7 @@ public class ServiceController {
             }
 
             // Session ID 추가
-            Session session = SessionService.getSession(userId);
+            Session session = SessionService.getSessionByUserId(userId);
             Map<String, String> headerMap = new HashMap<>();
             headerMap.put(HEADER_REDIRECT_LOCATION, INDEX_URL);
             headerMap.put(HEADER_SET_COOKIE, HEADER_SESSION_ID + session.getSessionId() + HEADER_COOKIE_PATH);

--- a/src/main/java/db/Database.java
+++ b/src/main/java/db/Database.java
@@ -8,8 +8,8 @@ import java.util.Collection;
 import java.util.Map;
 
 public class Database {
-    private static final Map<String, User> users = Maps.newHashMap();
-    private static final Map<String, Session> sessions = Maps.newHashMap();
+    private static final Map<String, User> users = Maps.newConcurrentMap();
+    private static final Map<String, Session> sessions = Maps.newConcurrentMap();
 
     // User
     public static void addUser(User user) {

--- a/src/main/java/http/HttpUtil.java
+++ b/src/main/java/http/HttpUtil.java
@@ -74,4 +74,5 @@ public class HttpUtil {
     public static final String HEADER_COOKIE_PATH = "; Path=/";
     public static final String INDEX_URL = "/index.html";
     public static final String LOGIN_FAILED_URL = "/user/login_failed.html";
+    public static final String USER_LIST_URL = "/user/list.html";
 }

--- a/src/main/java/http/HttpUtil.java
+++ b/src/main/java/http/HttpUtil.java
@@ -68,6 +68,7 @@ public class HttpUtil {
     public static final String HEADER_CONTENT_LENGTH = "Content-Length";
     public static final String HEADER_HTTP_VERSION = "1.1";
     public static final String HEADER_REDIRECT_LOCATION = "Location";
+    public static final String HEADER_COOKIE = "Cookie";
     public static final String HEADER_SET_COOKIE = "Set-Cookie";
     public static final String HEADER_SESSION_ID = "sid=";
     public static final String HEADER_COOKIE_PATH = "; Path=/";

--- a/src/main/java/service/FileService.java
+++ b/src/main/java/service/FileService.java
@@ -9,48 +9,8 @@ import static http.HttpUtil.*;
 import static service.SessionService.getUserIdBySid;
 
 public class FileService {
-    private static final String STATIC_FILEPATH = "./src/main/resources/static";
-    private static final String TEMPLATE_FILEPATH = "./src/main/resources/templates";
-    private static final String NAVBAR_RIGHT = "<li><a href=\"./user/list.html\"><i class=\"glyphicon glyphicon-user\"></i></a></li>";
-    private static final String USERNAME_FORMAT = "<li>%s</li>";
-    private static final String BUTTON_LOGOUT = "<li><a href=\"#\" role=\"button\">로그아웃</a></li>";
-    private static final String BUTTON_LOGIN = "<li><a href=\"user/login.html\" role=\"button\">로그인</a></li>";
-    private static final String BUTTON_SIGNUP = "<li><a href=\"user/form.html\" role=\"button\">회원가입</a></li>";
-    private static final String BUTTON_MODIFY_USERDATA = "<li><a href=\"#\" role=\"button\">개인정보수정</a></li>";
 
-    public static byte[] loadFile(Request request) throws IOException {
-        String targetUri = request.getTargetUri();
-        String targetPath;
-        byte[] body = null;
-
-        targetPath = STATIC_FILEPATH + targetUri;
-        if(new File(targetPath).exists()) {
-            body = readStaticFile(targetPath);
-        }
-        targetPath = TEMPLATE_FILEPATH + targetUri;
-        if(new File(targetPath).exists()) {
-            String sid = request.getSid();
-            body = renderTemplateFile(targetUri, sid);
-        }
-
-        return body;
-    }
-
-    private static byte[] readStaticFile(String route) throws IOException {
+    public static byte[] readStaticFile(String route) throws IOException {
         return Files.readAllBytes(new File(route).toPath());
-    }
-    private static byte[] renderTemplateFile(String targetUri, String sid) throws IOException {
-        String httpDocument = new String(readStaticFile(TEMPLATE_FILEPATH + targetUri));
-        if(sid == null) {
-            httpDocument = httpDocument.replace(BUTTON_LOGOUT, "");
-            httpDocument = httpDocument.replace(BUTTON_MODIFY_USERDATA, "");
-        }
-        else {
-            httpDocument = httpDocument.replace(NAVBAR_RIGHT, NAVBAR_RIGHT +
-                    String.format(USERNAME_FORMAT, getUserIdBySid(sid)));
-            httpDocument = httpDocument.replace(BUTTON_LOGIN, "");
-            httpDocument = httpDocument.replace(BUTTON_SIGNUP, "");
-        }
-        return httpDocument.getBytes();
     }
 }

--- a/src/main/java/service/FileService.java
+++ b/src/main/java/service/FileService.java
@@ -1,22 +1,56 @@
 package service;
 
+import webserver.model.Request;
+
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import static http.HttpUtil.*;
+import static service.SessionService.getUserIdBySid;
 
 public class FileService {
     private static final String STATIC_FILEPATH = "./src/main/resources/static";
     private static final String TEMPLATE_FILEPATH = "./src/main/resources/templates";
+    private static final String NAVBAR_RIGHT = "<li><a href=\"./user/list.html\"><i class=\"glyphicon glyphicon-user\"></i></a></li>";
+    private static final String USERNAME_FORMAT = "<li>%s</li>";
+    private static final String BUTTON_LOGOUT = "<li><a href=\"#\" role=\"button\">로그아웃</a></li>";
+    private static final String BUTTON_LOGIN = "<li><a href=\"user/login.html\" role=\"button\">로그인</a></li>";
+    private static final String BUTTON_SIGNUP = "<li><a href=\"user/form.html\" role=\"button\">회원가입</a></li>";
+    private static final String BUTTON_MODIFY_USERDATA = "<li><a href=\"#\" role=\"button\">개인정보수정</a></li>";
 
-    public static byte[] loadStaticFile(String route) throws IOException {
-        // 요청 경로의 파일을 반환
-        File f;
-        byte[] body;
-        // 두 가지의 경로 모두를 조회해야 합니다.
-        if (!(f = new File(STATIC_FILEPATH + route)).exists()) {
-            f = new File(TEMPLATE_FILEPATH + route);
+    public static byte[] loadFile(Request request) throws IOException {
+        String targetUri = request.getTargetUri();
+        String targetPath;
+        byte[] body = null;
+
+        targetPath = STATIC_FILEPATH + targetUri;
+        if(new File(targetPath).exists()) {
+            body = readStaticFile(targetPath);
         }
-        body = Files.readAllBytes(f.toPath());
+        targetPath = TEMPLATE_FILEPATH + targetUri;
+        if(new File(targetPath).exists()) {
+            String sid = request.getSid();
+            body = renderTemplateFile(targetUri, sid);
+        }
+
         return body;
+    }
+
+    private static byte[] readStaticFile(String route) throws IOException {
+        return Files.readAllBytes(new File(route).toPath());
+    }
+    private static byte[] renderTemplateFile(String targetUri, String sid) throws IOException {
+        String httpDocument = new String(readStaticFile(TEMPLATE_FILEPATH + targetUri));
+        if(sid == null) {
+            httpDocument = httpDocument.replace(BUTTON_LOGOUT, "");
+            httpDocument = httpDocument.replace(BUTTON_MODIFY_USERDATA, "");
+        }
+        else {
+            httpDocument = httpDocument.replace(NAVBAR_RIGHT, NAVBAR_RIGHT +
+                    String.format(USERNAME_FORMAT, getUserIdBySid(sid)));
+            httpDocument = httpDocument.replace(BUTTON_LOGIN, "");
+            httpDocument = httpDocument.replace(BUTTON_SIGNUP, "");
+        }
+        return httpDocument.getBytes();
     }
 }

--- a/src/main/java/service/SessionService.java
+++ b/src/main/java/service/SessionService.java
@@ -26,6 +26,10 @@ public class SessionService {
                 .findFirst()
                 .orElse(null);
     }
+    public static boolean isSessionValid(String sid) {
+        String userId = getUserIdBySid(sid);
+        return userId != null;
+    }
 
     public static Collection<Session> getAllSession() {
         return Database.findAllSession();

--- a/src/main/java/service/SessionService.java
+++ b/src/main/java/service/SessionService.java
@@ -4,10 +4,11 @@ import db.Database;
 import model.Session;
 
 import java.util.Collection;
+import java.util.Map;
 
 public class SessionService {
 
-    public static Session getSession(String userId) {
+    public static Session getSessionByUserId(String userId) {
         // 해당 userId에 해당하는 Session 존재하는지 확인
         Session session = Database.findSessionByUserId(userId);
         // 존재하지 않으면 새로 Session 생성하여 제공
@@ -17,6 +18,15 @@ public class SessionService {
 
         return session;
     }
+    public static String getUserIdBySid(String sid) {
+        Collection<Session> sessionList = Database.findAllSession();
+        return sessionList.stream()
+                .filter(session -> session.getSessionId().equals(sid))
+                .map(Session::getUserId)
+                .findFirst()
+                .orElse(null);
+    }
+
     public static Collection<Session> getAllSession() {
         return Database.findAllSession();
     }

--- a/src/main/java/service/UserService.java
+++ b/src/main/java/service/UserService.java
@@ -39,8 +39,8 @@ public class UserService {
             return false;
         }
 
-        // 아이디/비밀번호 검증
-        return userId.equals(user.getUserId()) && password.equals(user.getPassword());
+        // 비밀번호 검증
+        return password.equals(user.getPassword());
     }
 
     public static void clearUserDatabase() {

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -48,9 +48,8 @@ public class RequestHandler implements Runnable {
     private Request parseRequest(Socket connection) throws IOException, IllegalArgumentException {
         InputStream in = connection.getInputStream();
         BufferedReader br = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8));
-        /*
-         StartLine
-         */
+
+        // Status Line
         String[] tokens = readSingleHTTPLine(br).split(" ");
 
         Method method = Method.getMethodByName(tokens[0]);
@@ -59,9 +58,7 @@ public class RequestHandler implements Runnable {
 
         Map<String, String> queryParameterMap = parseQueryParameter(targetUri);
 
-        /*
-         Headers
-         */
+        // Headers
         Map<String, String> headerMap = new HashMap<>();
         String line = readSingleHTTPLine(br).replace(" ", "");
         while(!line.equals("")) {
@@ -69,10 +66,12 @@ public class RequestHandler implements Runnable {
             headerMap.put(tokens[0], tokens[1]);
             line = readSingleHTTPLine(br).replace(" ", "");
         }
+        String sid = null;
+        if(headerMap.containsKey(HEADER_COOKIE)) {
+            sid = headerMap.get(HEADER_COOKIE).split("=")[1];
+        }
 
-        /*
-         Body
-         */
+        // Body
         String body = "";
         if(method == Method.PUT || method == Method.POST) {
             int contentLength = Integer.parseInt(headerMap.get(HEADER_CONTENT_LENGTH));
@@ -82,7 +81,7 @@ public class RequestHandler implements Runnable {
             body = URLDecoder.decode(String.valueOf(bodyCharacters), StandardCharsets.UTF_8);
         }
 
-        return new Request(method, version, targetUri, queryParameterMap, headerMap, body);
+        return new Request(method, version, targetUri, queryParameterMap, headerMap, sid, body);
     }
 
     private Response generateResponse(Request request) throws Exception {

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -17,6 +17,7 @@ import java.util.Map;
 
 import static http.HttpUtil.*;
 import static http.HttpParser.*;
+import static service.SessionService.isSessionValid;
 
 public class RequestHandler implements Runnable {
     private static final Logger logger = LoggerFactory.getLogger(RequestHandler.class);
@@ -69,6 +70,9 @@ public class RequestHandler implements Runnable {
         String sid = null;
         if(headerMap.containsKey(HEADER_COOKIE)) {
             sid = headerMap.get(HEADER_COOKIE).split("=")[1];
+            if(!isSessionValid(sid)) {
+                sid = null;
+            }
         }
 
         // Body

--- a/src/main/java/webserver/model/Request.java
+++ b/src/main/java/webserver/model/Request.java
@@ -64,6 +64,10 @@ public class Request {
         return headerMap.get(key);
     }
 
+    public String getSid() {
+        return sid;
+    }
+
     public String getBody() {
         return body;
     }

--- a/src/main/java/webserver/model/Request.java
+++ b/src/main/java/webserver/model/Request.java
@@ -21,15 +21,18 @@ public class Request {
     private final String targetUri;
     private final Map<String, String> queryParameterMap;
     private final Map<String, String> headerMap;
+    private final String sid;
     private final String body;
 
     public Request(Method method, String version, String targetUri,
-                   Map<String, String> queryParameterMap, Map<String, String> headerMap, String body) {
+                   Map<String, String> queryParameterMap, Map<String, String> headerMap,
+                   String sid, String body) {
         this.method = method;
         this.version = version;
         this.targetUri = targetUri;
         this.queryParameterMap = queryParameterMap;
         this.headerMap = headerMap;
+        this.sid = sid;
         this.body = body;
     }
 
@@ -49,8 +52,16 @@ public class Request {
         return queryParameterMap;
     }
 
+    public String getQueryParameter(String key) {
+        return queryParameterMap.get(key);
+    }
+
     public Map<String, String> getHeaderMap() {
         return headerMap;
+    }
+
+    public String getHeader(String key) {
+        return headerMap.get(key);
     }
 
     public String getBody() {

--- a/src/main/resources/templates/user/list.html
+++ b/src/main/resources/templates/user/list.html
@@ -82,14 +82,7 @@
                     <th>#</th> <th>사용자 아이디</th> <th>이름</th> <th>이메일</th><th></th>
                 </tr>
               </thead>
-              <tbody>
-                <tr>
-                    <th scope="row">1</th> <td>javajigi</td> <td>자바지기</td> <td>javajigi@sample.net</td><td><a href="#" class="btn btn-success" role="button">수정</a></td>
-                </tr>
-                <tr>
-                    <th scope="row">2</th> <td>slipp</td> <td>슬립</td> <td>slipp@sample.net</td><td><a href="#" class="btn btn-success" role="button">수정</a></td>
-                </tr>
-              </tbody>
+              <tbody></tbody>
           </table>
         </div>
     </div>


### PR DESCRIPTION
## 구현 내용
- [x] 클라이언트 요청에서 sid를 파싱하는 로직 구현
- [x] 정적파일/가변렌더링 로직 구분
- [x] /user/list.html 동적 렌더링 및 리다이렉트 기능 구현
- [x] sid로 session이 유효한지 검증하는 로직 구현(미유효시 null로 저장)
- [x] 로그인/로그아웃/개인정보수정/회원가입 버튼이 상황에 맞게 표현되도록 구현
- [x] 로그인 상태일시 유저 닉네임이 표시되도록 구현

## 고민 사항
sid를 파싱하는 로직이 RequestHandler의 parseRequest메서드에 포함되어 있는데, 유효한 sid인지 검증하는 로직을 가져다 써야 하다보니 Service의 메서드가 RequestHandler에 사용되게 됐다. 가급적 책임 분리를 위해 Service의 메서드들은 Controller에서만 불리도록 하고 싶었는데, 어쩔 수 없이 이와 같이 되어버렸다. 추후에 parseRequest 메서드를 컨트롤러나 다른 곳으로 넘길지 고려해봐야 할 듯 하다.

## 기타
if문이 많이 중첩되어가고 있다... 별도로 빼는게 맞는건지 아직 모르겠어서 유지중인데, 너무 심해지면 따로 빼긴 해야할 듯 하다.