### PR TITLE
[김아현] step-5 쿠키를 이용한 로그인

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,12 @@
 
 Java Web Application Server 2023
 
-## step-4 POST로 회원 가입
+## step-5 쿠키를 이용한 로그인
 
-- 로그인을 GET에서 POST로 수정
-- redirection - 가입을 완료하면 /index.html 페이지로 이동
+- [x]  회원 가입 후 로그인
+- [x]  로그인 성공 시 HTTP header의 Set-Cookie 값 `SID = 세션 ID; Path=/`로 응답
+- [x]  로그인 실패 시 /user/login_failed.html로 redirection
+- [x]  Controller, ControllerMappingHandler에 싱글톤 패턴 적용
 
 ### 프로젝트 정보 
 

--- a/src/main/java/controller/BasicController.java
+++ b/src/main/java/controller/BasicController.java
@@ -1,17 +1,20 @@
 package controller;
 
+import exception.BadRequestException;
 import http.HttpRequest;
 import http.HttpResponse;
+
+import static exception.ExceptionList.INVALID_URI;
 
 public class BasicController extends Controller {
 
     @Override
     public HttpResponse.ResponseBuilder doGet(String uri) {
-        return null;
+        throw new BadRequestException(INVALID_URI);
     }
 
     @Override
     public HttpResponse.ResponseBuilder doPost(HttpRequest httpRequest) {
-        return null;
+        throw new BadRequestException(INVALID_URI);
     }
 }

--- a/src/main/java/controller/BasicController.java
+++ b/src/main/java/controller/BasicController.java
@@ -1,0 +1,17 @@
+package controller;
+
+import http.HttpRequest;
+import http.HttpResponse;
+
+public class BasicController extends Controller {
+
+    @Override
+    public HttpResponse.ResponseBuilder doGet(String uri) {
+        return null;
+    }
+
+    @Override
+    public HttpResponse.ResponseBuilder doPost(HttpRequest httpRequest) {
+        return null;
+    }
+}

--- a/src/main/java/controller/BasicController.java
+++ b/src/main/java/controller/BasicController.java
@@ -8,6 +8,17 @@ import static exception.ExceptionList.INVALID_URI;
 
 public class BasicController extends Controller {
 
+    private BasicController() {
+    }
+
+    private static class Holder {
+        private static final BasicController INSTANCE = new BasicController();
+    }
+
+    public static BasicController getInstance() {
+        return BasicController.Holder.INSTANCE;
+    }
+
     @Override
     public HttpResponse.ResponseBuilder doGet(String uri) {
         throw new BadRequestException(INVALID_URI);

--- a/src/main/java/controller/Controller.java
+++ b/src/main/java/controller/Controller.java
@@ -11,8 +11,8 @@ import static exception.ExceptionList.NOT_EXIST_USER;
 import static http.Extension.HTML;
 import static http.HttpMethod.POST;
 import static utils.FileIOUtils.*;
-import static http.FileName.LOGIN_FAILED;
-import static http.FileName.WRONG_ACCESS;
+import static http.FilePath.LOGIN_FAILED;
+import static http.FilePath.WRONG_ACCESS;
 
 public abstract class Controller {
     private final Page page = new Page();

--- a/src/main/java/controller/Controller.java
+++ b/src/main/java/controller/Controller.java
@@ -7,9 +7,12 @@ import http.HttpStatus;
 import http.MIME;
 import view.Page;
 
+import static exception.ExceptionList.NOT_EXIST_USER;
 import static http.Extension.HTML;
 import static http.HttpMethod.POST;
 import static utils.FileIOUtils.*;
+import static http.FileName.LOGIN_FAILED;
+import static http.FileName.WRONG_ACCESS;
 
 public abstract class Controller {
     private final Page page = new Page();
@@ -35,6 +38,8 @@ public abstract class Controller {
             return loadStaticFromPath(HttpStatus.OK, uri)
                     .setContentType(MIME.getMIME().get(extension));
         } catch (BadRequestException e) {
+            if (e.getMessage().equals(NOT_EXIST_USER))
+                return loadTemplatesFromPath(HttpStatus.UNAUTHORIZED, LOGIN_FAILED);
             String errorPage = page.getErrorPage(e.getMessage());
             return loadErrorFromPath(HttpStatus.NOT_FOUND, errorPage)
                     .setContentType(MIME.getMIME().get(HTML));

--- a/src/main/java/controller/Controller.java
+++ b/src/main/java/controller/Controller.java
@@ -1,0 +1,49 @@
+package controller;
+
+import exception.BadRequestException;
+import http.HttpRequest;
+import http.HttpResponse;
+import http.HttpStatus;
+import http.MIME;
+import view.Page;
+
+import static http.Extension.HTML;
+import static http.HttpMethod.POST;
+import static utils.FileIOUtils.*;
+
+public abstract class Controller {
+    private final Page page = new Page();
+
+    public HttpResponse.ResponseBuilder loadFileByRequest(HttpRequest httpRequest) {
+        try {
+            if (httpRequest.getMethod().equals(POST)) {
+                return doPost(httpRequest);
+            }
+            String uri = httpRequest.getUri();
+            if (uri.contains("?")) {
+                return doGet(uri);
+            }
+            String[] uris = uri.split("\\.");
+            String extension = uris[uris.length - 1];
+            if (MIME.getMIME().entrySet().stream().noneMatch(entry -> entry.getKey().equals(extension))) {
+                return loadTemplatesFromPath(HttpStatus.NOT_FOUND, "/wrong_access.html");
+            }
+            if (extension.equals(HTML)) {
+                return loadTemplatesFromPath(HttpStatus.OK, uri)
+                        .setContentType(MIME.getMIME().get(HTML));
+            }
+            return loadStaticFromPath(HttpStatus.OK, uri)
+                    .setContentType(MIME.getMIME().get(extension));
+        } catch (BadRequestException e) {
+            String errorPage = page.getErrorPage(e.getMessage());
+            return loadErrorFromPath(HttpStatus.NOT_FOUND, errorPage)
+                    .setContentType(MIME.getMIME().get(HTML));
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    public abstract HttpResponse.ResponseBuilder doGet(String uri);
+
+    public abstract HttpResponse.ResponseBuilder doPost(HttpRequest httpRequest);
+}

--- a/src/main/java/controller/Controller.java
+++ b/src/main/java/controller/Controller.java
@@ -26,7 +26,7 @@ public abstract class Controller {
             String[] uris = uri.split("\\.");
             String extension = uris[uris.length - 1];
             if (MIME.getMIME().entrySet().stream().noneMatch(entry -> entry.getKey().equals(extension))) {
-                return loadTemplatesFromPath(HttpStatus.NOT_FOUND, "/wrong_access.html");
+                return loadTemplatesFromPath(HttpStatus.NOT_FOUND, WRONG_ACCESS);
             }
             if (extension.equals(HTML)) {
                 return loadTemplatesFromPath(HttpStatus.OK, uri)

--- a/src/main/java/controller/Controller.java
+++ b/src/main/java/controller/Controller.java
@@ -2,6 +2,7 @@ package controller;
 
 import http.*;
 import service.UserService;
+import view.Page;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -14,6 +15,7 @@ import static utils.FileIOUtils.*;
 
 public class Controller {
     private final UserService userService = new UserService();
+    private final Page page = new Page();
 
     public HttpResponse.ResponseBuilder loadFileByRequest(HttpRequest httpRequest) {
         try {
@@ -36,23 +38,11 @@ public class Controller {
             return loadStaticFromPath(HttpStatus.OK, uri)
                     .setContentType(MIME.getMIME().get(extension));
         } catch (Exception e) {
-            String errorPage = getErrorPage(e.getMessage());
+            String errorPage = page.getErrorPage(e.getMessage());
             return loadErrorFromPath(HttpStatus.NOT_FOUND, errorPage)
                     .setContentType(MIME.getMIME().get(HTML));
         }
 
-    }
-
-    public String getErrorPage(String errorMessage) {
-        return "<!DOCTYPE html>" +
-                "<html>" +
-                "<head>" +
-                "<title>Error Page</title>" +
-                "</head>" +
-                "<body>" +
-                "<h1>Error: " + errorMessage + "</h1>" +
-                "</body>" +
-                "</html>";
     }
 
     private HttpResponse.ResponseBuilder routeByUriWithQuestion(String uri) {

--- a/src/main/java/controller/UserController.java
+++ b/src/main/java/controller/UserController.java
@@ -9,7 +9,7 @@ import java.util.Map;
 
 import static exception.ExceptionList.INVALID_URI;
 import static exception.ExceptionList.NOT_ENOUGH_USER_INFORMATION;
-import static http.FileName.INDEX;
+import static http.FilePath.INDEX;
 import static utils.FileIOUtils.*;
 
 public class UserController extends Controller {

--- a/src/main/java/controller/UserController.java
+++ b/src/main/java/controller/UserController.java
@@ -3,58 +3,26 @@ package controller;
 import exception.BadRequestException;
 import http.*;
 import service.UserService;
-import view.Page;
 
 import java.util.HashMap;
 import java.util.Map;
 
 import static exception.ExceptionName.INVALID_URI;
 import static exception.ExceptionName.NOT_ENOUGH_USER_INFORMATION;
-import static http.Extension.HTML;
-import static http.HttpMethod.POST;
 import static utils.FileIOUtils.*;
 
 public class UserController extends Controller {
     private final UserService userService = new UserService();
-    private final Page page = new Page();
 
-    public HttpResponse.ResponseBuilder loadFileByRequest(HttpRequest httpRequest) {
-        try {
-            if (httpRequest.getMethod().equals(POST)) {
-                return routeByUriWithBody(httpRequest);
-            }
-            String uri = httpRequest.getUri();
-            if (uri.contains("?")) {
-                return routeByUriWithQuestion(uri);
-            }
-            String[] uris = uri.split("\\.");
-            String extension = uris[uris.length - 1];
-            if (MIME.getMIME().entrySet().stream().noneMatch(entry -> entry.getKey().equals(extension))) {
-                return loadTemplatesFromPath(HttpStatus.NOT_FOUND, "/wrong_access.html");
-            }
-            if (extension.equals(HTML)) {
-                return loadTemplatesFromPath(HttpStatus.OK, uri)
-                        .setContentType(MIME.getMIME().get(HTML));
-            }
-            return loadStaticFromPath(HttpStatus.OK, uri)
-                    .setContentType(MIME.getMIME().get(extension));
-        } catch (Exception e) {
-            String errorPage = page.getErrorPage(e.getMessage());
-            return loadErrorFromPath(HttpStatus.NOT_FOUND, errorPage)
-                    .setContentType(MIME.getMIME().get(HTML));
-        }
-
-    }
-
-    private HttpResponse.ResponseBuilder routeByUriWithQuestion(String uri) {
+    public HttpResponse.ResponseBuilder doGet(String uri) {
         String[] apis = uri.split("\\?");
-        if (apis[0].equals("/user/create")) {
+        if (apis[0].equals("/user/create") && apis.length == 2) {
             return createUser(parseParams(apis[1]));
         }
         throw new BadRequestException(INVALID_URI);
     }
 
-    private HttpResponse.ResponseBuilder routeByUriWithBody(HttpRequest httpRequest) {
+    public HttpResponse.ResponseBuilder doPost(HttpRequest httpRequest) {
         String uri = httpRequest.getUri();
         if (uri.equals("/user/create")) {
             return createUser(parseParams(httpRequest.getBody()));

--- a/src/main/java/controller/UserController.java
+++ b/src/main/java/controller/UserController.java
@@ -7,8 +7,8 @@ import service.UserService;
 import java.util.HashMap;
 import java.util.Map;
 
-import static exception.ExceptionName.INVALID_URI;
-import static exception.ExceptionName.NOT_ENOUGH_USER_INFORMATION;
+import static exception.ExceptionList.INVALID_URI;
+import static exception.ExceptionList.NOT_ENOUGH_USER_INFORMATION;
 import static utils.FileIOUtils.*;
 
 public class UserController extends Controller {
@@ -26,6 +26,8 @@ public class UserController extends Controller {
         String uri = httpRequest.getUri();
         if (uri.equals("/user/create")) {
             return createUser(parseParams(httpRequest.getBody()));
+        } else if (uri.equals("/user/login")) {
+            return loginUser(parseParams(httpRequest.getBody()));
         }
         throw new BadRequestException(INVALID_URI);
     }
@@ -45,6 +47,12 @@ public class UserController extends Controller {
     private HttpResponse.ResponseBuilder createUser(Map<String, String> parameters) {
         userService.createUser(parameters);
         return loadTemplatesFromPath(HttpStatus.FOUND, "/index.html");
+    }
+
+    private HttpResponse.ResponseBuilder loginUser(Map<String, String> parameters) {
+        String sessionId = userService.loginUser(parameters);
+        return loadTemplatesFromPath(HttpStatus.FOUND, "/index.html")
+                .setSessionId(sessionId);
     }
 
 }

--- a/src/main/java/controller/UserController.java
+++ b/src/main/java/controller/UserController.java
@@ -9,6 +9,7 @@ import java.util.Map;
 
 import static exception.ExceptionList.INVALID_URI;
 import static exception.ExceptionList.NOT_ENOUGH_USER_INFORMATION;
+import static http.FileName.INDEX;
 import static utils.FileIOUtils.*;
 
 public class UserController extends Controller {
@@ -46,12 +47,12 @@ public class UserController extends Controller {
 
     private HttpResponse.ResponseBuilder createUser(Map<String, String> parameters) {
         userService.createUser(parameters);
-        return loadTemplatesFromPath(HttpStatus.FOUND, "/index.html");
+        return loadTemplatesFromPath(HttpStatus.FOUND, INDEX);
     }
 
     private HttpResponse.ResponseBuilder loginUser(Map<String, String> parameters) {
         String sessionId = userService.loginUser(parameters);
-        return loadTemplatesFromPath(HttpStatus.FOUND, "/index.html")
+        return loadTemplatesFromPath(HttpStatus.FOUND, INDEX)
                 .setSessionId(sessionId);
     }
 

--- a/src/main/java/controller/UserController.java
+++ b/src/main/java/controller/UserController.java
@@ -1,5 +1,6 @@
 package controller;
 
+import exception.BadRequestException;
 import http.*;
 import service.UserService;
 import view.Page;
@@ -50,7 +51,7 @@ public class Controller {
         if (apis[0].equals("/user/create")) {
             return createUser(parseParams(apis[1]));
         }
-        throw new IllegalArgumentException(INVALID_URI);
+        throw new BadRequestException(INVALID_URI);
     }
 
     private HttpResponse.ResponseBuilder routeByUriWithBody(HttpRequest httpRequest) {
@@ -58,7 +59,7 @@ public class Controller {
         if (uri.equals("/user/create")) {
             return createUser(parseParams(httpRequest.getBody()));
         }
-        throw new IllegalArgumentException(INVALID_URI);
+        throw new BadRequestException(INVALID_URI);
     }
 
     private Map<String, String> parseParams(String parameter) {
@@ -67,7 +68,7 @@ public class Controller {
         for (String param : params) {
             String[] info = param.split("=");
             if (info.length != 2)
-                throw new IllegalArgumentException(NOT_ENOUGH_USER_INFORMATION);
+                throw new BadRequestException(NOT_ENOUGH_USER_INFORMATION);
             information.put(info[0], info[1]);
         }
         return information;

--- a/src/main/java/controller/UserController.java
+++ b/src/main/java/controller/UserController.java
@@ -15,6 +15,17 @@ import static utils.FileIOUtils.*;
 public class UserController extends Controller {
     private final UserService userService = new UserService();
 
+    private UserController() {
+    }
+
+    private static class Holder {
+        private static final UserController INSTANCE = new UserController();
+    }
+
+    public static UserController getInstance() {
+        return UserController.Holder.INSTANCE;
+    }
+
     public HttpResponse.ResponseBuilder doGet(String uri) {
         String[] apis = uri.split("\\?");
         if (apis[0].equals("/user/create") && apis.length == 2) {

--- a/src/main/java/controller/UserController.java
+++ b/src/main/java/controller/UserController.java
@@ -14,7 +14,7 @@ import static http.Extension.HTML;
 import static http.HttpMethod.POST;
 import static utils.FileIOUtils.*;
 
-public class Controller {
+public class UserController extends Controller {
     private final UserService userService = new UserService();
     private final Page page = new Page();
 

--- a/src/main/java/db/Database.java
+++ b/src/main/java/db/Database.java
@@ -8,7 +8,7 @@ import java.util.Collection;
 import java.util.Map;
 
 public class Database {
-    private static Map<String, User> users = Maps.newHashMap();
+    private static Map<String, User> users = Maps.newConcurrentMap();
 
     public static void addUser(User user) {
         users.put(user.getUserId(), user);

--- a/src/main/java/db/SessionDatabase.java
+++ b/src/main/java/db/SessionDatabase.java
@@ -1,0 +1,32 @@
+package db;
+
+import com.google.common.collect.Maps;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.UUID;
+
+public class SessionDatabase {
+
+    private static Map<String, String> sessionIds = Maps.newConcurrentMap();
+
+    public static void addSessionId(String userId, String sessionId) {
+        sessionIds.put(userId, sessionId);
+    }
+
+    public static void deleteSessionId(String userId) {
+        sessionIds.remove(userId);
+    }
+
+    public static String createSessionId() {
+        return UUID.randomUUID().toString();
+    }
+
+    public static Collection<String> findAllSessionIds() {
+        return sessionIds.values();
+    }
+
+    public static void clearSessionIds() {
+        sessionIds.clear();
+    }
+}

--- a/src/main/java/exception/BadRequestException.java
+++ b/src/main/java/exception/BadRequestException.java
@@ -1,0 +1,7 @@
+package exception;
+
+public class BadRequestException extends RuntimeException {
+    public BadRequestException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/exception/ExceptionList.java
+++ b/src/main/java/exception/ExceptionList.java
@@ -1,0 +1,8 @@
+package exception;
+
+public final class ExceptionList {
+    public static final String ALREADY_EXIST_USER = "이미 존재하는 회원입니다.";
+    public static final String NOT_ENOUGH_USER_INFORMATION = "회원 가입/로그인을 완료하려면 모든 정보를 입력해주세요.";
+    public static final String NOT_EXIST_USER = "사용자 정보가 없습니다.";
+    public static final String INVALID_URI = "URI가 유효하지 않습니다.";
+}

--- a/src/main/java/exception/ExceptionName.java
+++ b/src/main/java/exception/ExceptionName.java
@@ -1,7 +1,0 @@
-package exception;
-
-public final class ExceptionName {
-    public static final String ALREADY_EXIST_USER = "이미 존재하는 회원입니다.";
-    public static final String NOT_ENOUGH_USER_INFORMATION = "회원 가입을 완료하려면 모든 정보를 입력해주세요.";
-    public static final String INVALID_URI = "URI가 적절하지 않습니다.";
-}

--- a/src/main/java/handler/ControllerMappingHandler.java
+++ b/src/main/java/handler/ControllerMappingHandler.java
@@ -7,8 +7,19 @@ import http.HttpRequest;
 
 public class ControllerMappingHandler {
 
-    UserController userController = new UserController();
-    BasicController basicController = new BasicController();
+    UserController userController = UserController.getInstance();
+    BasicController basicController = BasicController.getInstance();
+
+    private ControllerMappingHandler() {
+    }
+
+    private static class Holder {
+        private static final ControllerMappingHandler INSTANCE = new ControllerMappingHandler();
+    }
+
+    public static ControllerMappingHandler getInstance() {
+        return Holder.INSTANCE;
+    }
 
     public Controller mappingController(HttpRequest httpRequest) {
         String uri = httpRequest.getUri();

--- a/src/main/java/handler/ControllerMappingHandler.java
+++ b/src/main/java/handler/ControllerMappingHandler.java
@@ -1,0 +1,20 @@
+package handler;
+
+import controller.BasicController;
+import controller.Controller;
+import controller.UserController;
+import http.HttpRequest;
+
+public class ControllerMappingHandler {
+
+    UserController userController = new UserController();
+    BasicController basicController = new BasicController();
+
+    public Controller mappingController(HttpRequest httpRequest) {
+        String uri = httpRequest.getUri();
+        if (uri.startsWith("/user")) {
+            return userController;
+        }
+        return basicController;
+    }
+}

--- a/src/main/java/http/FileName.java
+++ b/src/main/java/http/FileName.java
@@ -1,0 +1,7 @@
+package http;
+
+public class FileName {
+    public static final String INDEX = "/index.html";
+    public static final String LOGIN_FAILED = "/user/login_failed.html";
+    public static final String WRONG_ACCESS = "/wrong_access.html";
+}

--- a/src/main/java/http/FilePath.java
+++ b/src/main/java/http/FilePath.java
@@ -1,6 +1,6 @@
 package http;
 
-public class FileName {
+public class FilePath {
     public static final String INDEX = "/index.html";
     public static final String LOGIN_FAILED = "/user/login_failed.html";
     public static final String WRONG_ACCESS = "/wrong_access.html";

--- a/src/main/java/http/HttpResponse.java
+++ b/src/main/java/http/HttpResponse.java
@@ -14,6 +14,7 @@ public class HttpResponse {
     private HttpStatus httpStatus;
     private String contentType;
     private String location;
+    private String sessionId;
     private byte[] body;
 
     public static class ResponseBuilder {
@@ -21,6 +22,7 @@ public class HttpResponse {
         private HttpStatus httpStatus = HttpStatus.OK;
         private String contentType = MIME.getMIME().get(HTML);
         private String location = "/index.html";
+        private String sessionId;
         private byte[] body;
 
         public ResponseBuilder() {
@@ -41,6 +43,11 @@ public class HttpResponse {
             return this;
         }
 
+        public ResponseBuilder setSessionId(String sessionId) {
+            this.sessionId = sessionId;
+            return this;
+        }
+
         public ResponseBuilder setBody(byte[] body) {
             this.body = body;
             return this;
@@ -55,6 +62,7 @@ public class HttpResponse {
         this.httpStatus = builder.httpStatus;
         this.contentType = builder.contentType;
         this.location = builder.location;
+        this.sessionId = builder.sessionId;
         this.body = builder.body;
     }
 
@@ -70,15 +78,18 @@ public class HttpResponse {
             String contentTypeLine = String.format("Content-Type: %s;charset=utf-8 \r\n", contentType);
             String contentLengthLine = String.format("Content-Length: %d \r\n", body.length);
             String locationLine = String.format("Location: %s \r\n", location);
+            String setCookieLine = sessionId == null ? "" : String.format("Set-Cookie: SID = %s; Path=/ \r\n", sessionId);
             dos.writeBytes(statusLine);
             dos.writeBytes(contentTypeLine);
             dos.writeBytes(contentLengthLine);
             dos.writeBytes(locationLine);
+            dos.writeBytes(setCookieLine);
             dos.writeBytes("\r\n");
             logger.debug(statusLine);
             logger.debug(contentTypeLine);
             logger.debug(contentLengthLine);
             logger.debug(locationLine);
+            logger.debug(setCookieLine);
         } catch (IOException e) {
             logger.error(e.getMessage());
         }

--- a/src/main/java/http/MIME.java
+++ b/src/main/java/http/MIME.java
@@ -19,8 +19,8 @@ public class MIME {
         MIME.put("txt", "text/plain");
         MIME.put("eot", "application/vnd.ms-fontobject");
         MIME.put("svg", "image/svg+xml");
-        MIME.put("ttf", "application/x-font-ttf");    // OR font/ttf
-        MIME.put("woff", "application/font-woff");    // OR font/woff
+        MIME.put("ttf", "font/ttf");    // OR application/x-font-ttf
+        MIME.put("woff", "font/woff");    // OR application/font-woff
         MIME.put("woff2", "font/woff2");
     }
 

--- a/src/main/java/service/UserService.java
+++ b/src/main/java/service/UserService.java
@@ -6,7 +6,9 @@ import model.User;
 import java.util.Map;
 
 import static db.Database.*;
-import static exception.ExceptionName.ALREADY_EXIST_USER;
+import static db.SessionDatabase.*;
+import static exception.ExceptionList.ALREADY_EXIST_USER;
+import static exception.ExceptionList.NOT_EXIST_USER;
 
 public class UserService {
     private String USERID = "userId";
@@ -22,5 +24,22 @@ public class UserService {
     private void checkUserAlreadyExist(String userId) {
         if (findAll().stream().anyMatch(user -> user.getUserId().equals(userId)))
             throw new BadRequestException(ALREADY_EXIST_USER);
+    }
+
+    public String loginUser(Map<String, String> userInfo) {
+        checkUserExist(userInfo);
+        String sessionId = createSessionId();
+        addSessionId(userInfo.get(USERID), sessionId);
+        return sessionId;
+    }
+
+    private void checkUserExist(Map<String, String> userInfo) {
+        if (findAll().stream().noneMatch(user -> user.getUserId().equals(userInfo.get(USERID)) &&
+                                                 user.getPassword().equals(userInfo.get(PASSWORD))))
+            throw new BadRequestException(NOT_EXIST_USER);
+    }
+
+    private boolean checkSessionIdExist(String sessionId) {
+        return findAllSessionIds().stream().anyMatch(id -> id.equals(sessionId));
     }
 }

--- a/src/main/java/service/UserService.java
+++ b/src/main/java/service/UserService.java
@@ -11,10 +11,11 @@ import static exception.ExceptionList.ALREADY_EXIST_USER;
 import static exception.ExceptionList.NOT_EXIST_USER;
 
 public class UserService {
-    private String USERID = "userId";
-    private String PASSWORD = "password";
-    private String NAME = "name";
-    private String EMAIL = "email";
+    private final String USERID = "userId";
+    private final String PASSWORD = "password";
+    private final String NAME = "name";
+    private final String EMAIL = "email";
+
     public void createUser(Map<String, String> userInfo) {
         checkUserAlreadyExist(userInfo.get(USERID));
         User user = new User(userInfo.get(USERID), userInfo.get(PASSWORD), userInfo.get(NAME), userInfo.get(EMAIL));
@@ -35,7 +36,7 @@ public class UserService {
 
     private void checkUserExist(Map<String, String> userInfo) {
         if (findAll().stream().noneMatch(user -> user.getUserId().equals(userInfo.get(USERID)) &&
-                                                 user.getPassword().equals(userInfo.get(PASSWORD))))
+                user.getPassword().equals(userInfo.get(PASSWORD))))
             throw new BadRequestException(NOT_EXIST_USER);
     }
 

--- a/src/main/java/service/UserService.java
+++ b/src/main/java/service/UserService.java
@@ -1,5 +1,6 @@
 package service;
 
+import exception.BadRequestException;
 import model.User;
 
 import java.util.Map;
@@ -20,6 +21,6 @@ public class UserService {
 
     private void checkUserAlreadyExist(String userId) {
         if (findAll().stream().anyMatch(user -> user.getUserId().equals(userId)))
-            throw new IllegalArgumentException(ALREADY_EXIST_USER);
+            throw new BadRequestException(ALREADY_EXIST_USER);
     }
 }

--- a/src/main/java/utils/FileIOUtils.java
+++ b/src/main/java/utils/FileIOUtils.java
@@ -15,36 +15,26 @@ public class FileIOUtils {
     public static final String TEMPLATES_RESOURCES = "src/main/resources/templates";
 
     public static HttpResponse.ResponseBuilder loadStaticFromPath(HttpStatus httpStatus, String uri) {
-        Path path = Paths.get(STATIC_RESOURCES + uri);
-        try {
-            if (Files.exists(path)) {
-                return new HttpResponse.ResponseBuilder()
-                        .setStatus(httpStatus)
-                        .setLocation(uri)
-                        .setBody(Files.readAllBytes(new File(STATIC_RESOURCES + uri).toPath()));
-            }
-            return new HttpResponse.ResponseBuilder()
-                    .setStatus(HttpStatus.NOT_FOUND)
-                    .setLocation("/wrong_access.html")
-                    .setBody(Files.readAllBytes(new File(TEMPLATES_RESOURCES + "/wrong_access.html").toPath()));
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
+        return loadFromPath(STATIC_RESOURCES, httpStatus, uri);
     }
 
     public static HttpResponse.ResponseBuilder loadTemplatesFromPath(HttpStatus httpStatus, String uri) {
-        Path path = Paths.get(TEMPLATES_RESOURCES + uri);
+        return loadFromPath(TEMPLATES_RESOURCES, httpStatus, uri);
+    }
+
+    private static HttpResponse.ResponseBuilder loadFromPath(String resourcePath, HttpStatus httpStatus, String uri) {
+        Path path = Paths.get(resourcePath + uri);
         try {
             if (Files.exists(path)) {
                 return new HttpResponse.ResponseBuilder()
                         .setStatus(httpStatus)
                         .setLocation(uri)
-                        .setBody(Files.readAllBytes(new File(TEMPLATES_RESOURCES + uri).toPath()));
+                        .setBody(Files.readAllBytes(new File(resourcePath + uri).toPath()));
             }
             return new HttpResponse.ResponseBuilder()
                     .setStatus(HttpStatus.NOT_FOUND)
                     .setLocation("/wrong_access.html")
-                    .setBody(Files.readAllBytes(new File(TEMPLATES_RESOURCES + "/wrong_access.html").toPath()));
+                    .setBody(Files.readAllBytes(new File(resourcePath + "/wrong_access.html").toPath()));
         } catch (IOException e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/view/Page.java
+++ b/src/main/java/view/Page.java
@@ -1,0 +1,16 @@
+package view;
+
+public class Page {
+
+    public String getErrorPage(String errorMessage) {
+        return "<!DOCTYPE html>" +
+                "<html>" +
+                "<head>" +
+                "<title>Error Page</title>" +
+                "</head>" +
+                "<body>" +
+                "<h1>Error: " + errorMessage + "</h1>" +
+                "</body>" +
+                "</html>";
+    }
+}

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -7,6 +7,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import controller.Controller;
+import handler.ControllerMappingHandler;
 import http.HttpResponse;
 import http.HttpRequest;
 import org.slf4j.Logger;
@@ -18,7 +19,8 @@ public class RequestHandler implements Runnable {
     private static final Logger logger = LoggerFactory.getLogger(RequestHandler.class);
     private final Socket connection;
 
-    private final Controller controller = new Controller();
+
+    private final ControllerMappingHandler controllerMappingHandler = new ControllerMappingHandler();
 
     public RequestHandler(Socket connectionSocket) {
         this.connection = connectionSocket;
@@ -34,6 +36,7 @@ public class RequestHandler implements Runnable {
             HttpRequest httpRequest = createRequest(in);
 
             assert httpRequest != null;
+            Controller controller = controllerMappingHandler.mappingController(httpRequest);
             HttpResponse.ResponseBuilder responseBuilder = controller.loadFileByRequest(httpRequest);
 
             HttpResponse httpResponse = responseBuilder.build();

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -13,7 +13,6 @@ import http.HttpRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static db.Database.addUserTest;
 import static http.HttpMethod.POST;
 
 public class RequestHandler implements Runnable {
@@ -33,8 +32,6 @@ public class RequestHandler implements Runnable {
         try (InputStream in = connection.getInputStream(); OutputStream out = connection.getOutputStream()) {
             // 사용자 요청에 대한 처리 구현
             HttpRequest httpRequest = createRequest(in);
-            // todo test 지우기~
-            addUserTest();
 
             assert httpRequest != null;
             Controller controller = controllerMappingHandler.mappingController(httpRequest);

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -13,14 +13,13 @@ import http.HttpRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static db.Database.addUserTest;
 import static http.HttpMethod.POST;
 
 public class RequestHandler implements Runnable {
     private static final Logger logger = LoggerFactory.getLogger(RequestHandler.class);
     private final Socket connection;
-
-
-    private final ControllerMappingHandler controllerMappingHandler = new ControllerMappingHandler();
+    private final ControllerMappingHandler controllerMappingHandler = ControllerMappingHandler.getInstance();
 
     public RequestHandler(Socket connectionSocket) {
         this.connection = connectionSocket;
@@ -34,6 +33,8 @@ public class RequestHandler implements Runnable {
         try (InputStream in = connection.getInputStream(); OutputStream out = connection.getOutputStream()) {
             // 사용자 요청에 대한 처리 구현
             HttpRequest httpRequest = createRequest(in);
+            // todo test 지우기~
+            addUserTest();
 
             assert httpRequest != null;
             Controller controller = controllerMappingHandler.mappingController(httpRequest);

--- a/src/test/java/controller/BasicControllerTest.java
+++ b/src/test/java/controller/BasicControllerTest.java
@@ -31,7 +31,7 @@ class BasicControllerTest {
 
     @Test
     @DisplayName("존재하지 않는 리소스에 대한 요청 시 NOT_FOUND 404 상태를 반환해야 한다")
-    void wrongRequestNoFile() {
+    void badRequestNoFile() {
         // Given
         HttpRequest httpRequest = new HttpRequest.RequestBuilder(GET, "/no_index.html", "HTTP/1.1").build();
 

--- a/src/test/java/controller/BasicControllerTest.java
+++ b/src/test/java/controller/BasicControllerTest.java
@@ -20,7 +20,7 @@ class BasicControllerTest {
 
     @BeforeEach
     void setup() {
-        basicController = new BasicController();
+        basicController = BasicController.getInstance();
         softAssertions = new SoftAssertions();
     }
 

--- a/src/test/java/controller/BasicControllerTest.java
+++ b/src/test/java/controller/BasicControllerTest.java
@@ -1,0 +1,45 @@
+package controller;
+
+import http.HttpRequest;
+import http.HttpResponse;
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static http.HttpMethod.GET;
+import static http.HttpStatus.NOT_FOUND;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class BasicControllerTest {
+
+    BasicController basicController;
+    SoftAssertions softAssertions;
+
+    @BeforeEach
+    void setup() {
+        basicController = new BasicController();
+        softAssertions = new SoftAssertions();
+    }
+
+    @AfterEach
+    void after() {
+        softAssertions.assertAll();
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 리소스에 대한 요청 시 NOT_FOUND 404 상태를 반환해야 한다")
+    void wrongRequestNoFile() {
+        // Given
+        HttpRequest httpRequest = new HttpRequest.RequestBuilder(GET, "/no_index.html", "HTTP/1.1").build();
+
+        // When
+        HttpResponse httpResponse = basicController.loadFileByRequest(httpRequest).build();
+
+        // Then
+        assertThat(httpResponse.getHttpStatus()).isEqualTo(NOT_FOUND);
+    }
+
+}

--- a/src/test/java/controller/UserControllerTest.java
+++ b/src/test/java/controller/UserControllerTest.java
@@ -6,6 +6,7 @@ import http.HttpResponse;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.*;
 
+import static controller.UserController.getInstance;
 import static db.Database.clear;
 import static http.HttpMethod.GET;
 import static http.HttpMethod.POST;
@@ -19,7 +20,7 @@ class UserControllerTest {
 
     @BeforeEach
     void setup() {
-        userController = new UserController();
+        userController = getInstance();
         softAssertions = new SoftAssertions();
     }
 
@@ -68,7 +69,6 @@ class UserControllerTest {
         HttpRequest httpRequest = new HttpRequest.RequestBuilder("POST", uri, "HTTP/1.1")
                 .setBody(body)
                 .build();
-        UserController userController = new UserController();
 
         // When
         userController.loadFileByRequest(httpRequest);
@@ -89,7 +89,6 @@ class UserControllerTest {
         HttpRequest httpRequest = new HttpRequest.RequestBuilder("POST", uri, "HTTP/1.1")
                 .setBody(body)
                 .build();
-        UserController userController = new UserController();
 
         // When
         HttpResponse httpResponse = userController.loadFileByRequest(httpRequest).build();

--- a/src/test/java/controller/UserControllerTest.java
+++ b/src/test/java/controller/UserControllerTest.java
@@ -80,7 +80,7 @@ class UserControllerTest {
                 .as("Id로 이름을 찾을 수 없습니다.\n 현재 값: %s", Database.findUserById("kimahhh").getName()).isEqualTo("김아현");
     }
     @Test
-    @DisplayName("유저가 회원가입 시 정보를 모두 입력하지 않는 경우, NOT_FOUND 404 상태를 반환해야 한다")
+    @DisplayName("유저가 회원가입 혹은 로그인 시 정보를 모두 입력하지 않는 경우, NOT_FOUND 404 상태를 반환해야 한다")
     void notEnoughInformation() {
         // Given
         clear();

--- a/src/test/java/controller/UserControllerTest.java
+++ b/src/test/java/controller/UserControllerTest.java
@@ -29,21 +29,8 @@ class UserControllerTest {
     }
 
     @Test
-    @DisplayName("존재하지 않는 리소스에 대한 요청 시 NOT_FOUND 404 상태를 반환해야 한다")
-    void wrongRequestNoFile() {
-        // Given
-        HttpRequest httpRequest = new HttpRequest.RequestBuilder(GET, "/no_index.html", "HTTP/1.1").build();
-
-        // When
-        HttpResponse httpResponse = userController.loadFileByRequest(httpRequest).build();
-
-        // Then
-        assertThat(httpResponse.getHttpStatus()).isEqualTo(NOT_FOUND);
-    }
-
-    @Test
     @DisplayName("GET 방식 사용 시: 존재하지 않는 경로인 경우 NOT_FOUND 404 상태를 반환해야 한다")
-    void wrongRequestUriUsingGet() {
+    void badRequestUriUsingGet() {
         // Given
         String uri = "/user/user/create?userId=kimahhh&password=1234&name=김아현&email=kimahyunn132@gmail.com";
         HttpRequest httpRequest = new HttpRequest.RequestBuilder(GET, uri, "HTTP/1.1").build();
@@ -57,7 +44,7 @@ class UserControllerTest {
 
     @Test
     @DisplayName("POST 방식 사용 시: 존재하지 않는 경로인 경우 NOT_FOUND 404 상태를 반환해야 한다")
-    void wrongRequestUriUsingPost() {
+    void badRequestUriUsingPost() {
         // Given
         String uri = "/user/user/create";
         HttpRequest httpRequest = new HttpRequest.RequestBuilder(POST, uri, "HTTP/1.1")
@@ -72,7 +59,7 @@ class UserControllerTest {
     }
 
     @Test
-    @DisplayName("유저가 회원가입 시 Database에 정보가 추가되어야 한다")
+    @DisplayName("유저가 회원가입 시, Database에 정보가 추가되어야 한다")
     void signUp() {
         // Given
         clear();

--- a/src/test/java/controller/UserControllerTest.java
+++ b/src/test/java/controller/UserControllerTest.java
@@ -11,16 +11,15 @@ import static http.HttpMethod.GET;
 import static http.HttpMethod.POST;
 import static http.HttpStatus.NOT_FOUND;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
-class ControllerTest {
+class UserControllerTest {
 
-    Controller controller;
+    UserController userController;
     SoftAssertions softAssertions;
 
     @BeforeEach
     void setup() {
-        controller = new Controller();
+        userController = new UserController();
         softAssertions = new SoftAssertions();
     }
 
@@ -36,7 +35,7 @@ class ControllerTest {
         HttpRequest httpRequest = new HttpRequest.RequestBuilder(GET, "/no_index.html", "HTTP/1.1").build();
 
         // When
-        HttpResponse httpResponse = controller.loadFileByRequest(httpRequest).build();
+        HttpResponse httpResponse = userController.loadFileByRequest(httpRequest).build();
 
         // Then
         assertThat(httpResponse.getHttpStatus()).isEqualTo(NOT_FOUND);
@@ -50,7 +49,7 @@ class ControllerTest {
         HttpRequest httpRequest = new HttpRequest.RequestBuilder(GET, uri, "HTTP/1.1").build();
 
         // When
-        HttpResponse httpResponse = controller.loadFileByRequest(httpRequest).build();
+        HttpResponse httpResponse = userController.loadFileByRequest(httpRequest).build();
 
         // Then
         assertThat(httpResponse.getHttpStatus()).isEqualTo(NOT_FOUND);
@@ -66,7 +65,7 @@ class ControllerTest {
                 .build();
 
         // When
-        HttpResponse httpResponse = controller.loadFileByRequest(httpRequest).build();
+        HttpResponse httpResponse = userController.loadFileByRequest(httpRequest).build();
 
         // Then
         assertThat(httpResponse.getHttpStatus()).isEqualTo(NOT_FOUND);
@@ -82,10 +81,10 @@ class ControllerTest {
         HttpRequest httpRequest = new HttpRequest.RequestBuilder("POST", uri, "HTTP/1.1")
                 .setBody(body)
                 .build();
-        Controller controller = new Controller();
+        UserController userController = new UserController();
 
         // When
-        controller.loadFileByRequest(httpRequest);
+        userController.loadFileByRequest(httpRequest);
 
         // Then
         softAssertions.assertThat(Database.findAll().size())
@@ -103,10 +102,10 @@ class ControllerTest {
         HttpRequest httpRequest = new HttpRequest.RequestBuilder("POST", uri, "HTTP/1.1")
                 .setBody(body)
                 .build();
-        Controller controller = new Controller();
+        UserController userController = new UserController();
 
         // When
-        HttpResponse httpResponse = controller.loadFileByRequest(httpRequest).build();
+        HttpResponse httpResponse = userController.loadFileByRequest(httpRequest).build();
 
         // Then
         softAssertions.assertThat(httpResponse.getHttpStatus())

--- a/src/test/java/service/UserServiceTest.java
+++ b/src/test/java/service/UserServiceTest.java
@@ -12,7 +12,6 @@ import static db.Database.clear;
 import static db.SessionDatabase.clearSessionIds;
 import static exception.ExceptionList.ALREADY_EXIST_USER;
 import static exception.ExceptionList.NOT_EXIST_USER;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 class UserServiceTest {
@@ -51,7 +50,6 @@ class UserServiceTest {
         userService.createUser(user1);
 
         // Then
-        SoftAssertions softAssertions = new SoftAssertions();
         softAssertions.assertThat(Database.findAll().size())
                 .as("Database의 크기가 1이 아닙니다.\n현재 값: %d", Database.findAll().size())
                 .isEqualTo(1);
@@ -93,7 +91,7 @@ class UserServiceTest {
         });
 
         // Then
-        assertThat(exception.getMessage())
+        softAssertions.assertThat(exception.getMessage())
                 .as("적절한 오류가 던져지지 않습니다.\n현재 값: %s", exception.getMessage())
                 .isEqualTo(ALREADY_EXIST_USER);
     }
@@ -118,7 +116,7 @@ class UserServiceTest {
         });
 
         // Then
-        assertThat(exception.getMessage())
+        softAssertions.assertThat(exception.getMessage())
                 .as("적절한 오류가 던져지지 않습니다.\n현재 값: %s", exception.getMessage())
                 .isEqualTo(NOT_EXIST_USER);
     }


### PR DESCRIPTION
## 구현 내용
- [x]  회원 가입 후 로그인
- [x]  로그인 성공 시 HTTP header의 Set-Cookie 값 `SID = 세션 ID; Path=/`로 응답
- [x]  로그인 실패 시 /user/login_failed.html로 redirection
- [x]  Controller, ControllerMappingHandler에 싱글톤 패턴 적용

## 고민 사항
- ControllerMappingHandler
    - 지금은 User와 관련된 일만 처리하기 때문에 Controller가 여러 개 필요 없지만 추후 도메인 추가를 고려해서 Controller 추상 클래스를 구현하고 이 클래스를 상속받는 `UserController`(User와 관련된 일 처리)와 `BasicController`(파일 load 하는 일을 처리)를 구현
    - uri가 무엇으로 시작하는지(”/user”, …)에 따라 Controller 선택
- 세션 아이디
    - `Set-Cookie`를 사용해서 세션 아이디를 응답했지만 적용이 안 되는 현상 발생
    - 피어 세션을 통해 원인 발견 - 세션 아이디를 응답한 후 다음 응답에서 세션 아이디를 `“”`로 설정해서 응답을 보내고 있었음
    - 세션 아이디를 설정한 경우만 헤더에 `Set-Cookie`를 담아 보내고 아닌 경우는 보내지 않는 방식으로 해결
- 반환하기 위한 파일 path를 메소드 호출 시 String으로 작성해서 보냄
    - 어디서 어떤 파일을 반환했는지 찾기 힘든 상황 발생
    - `FilePath` 클래스를 만들어 path의 String을 static final로 관리