### PR TITLE
[신동우] step-4 POST로 회원 가입

### DIFF
--- a/src/test/java/controllers/ControllerTest.java
+++ b/src/test/java/controllers/ControllerTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.AssertionsForClassTypes.*;
 import java.util.Map;
 
 import org.assertj.core.api.SoftAssertions;
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;


### PR DESCRIPTION
## 구현 내용
- [x] 로그인을 GET에서 POST로 동작하도록 변경한다
- [x] 가입을 완료하면 /index.html 페이지로 이동한다

## 고민 사항
- **Post Request의 Body Content-Type**
  Body 파싱을 만들고 Postman을 사용해 테스트를 진행했는데, Body로 들어오는 형식이 예상했던 것과 달랐다. 다시 Postman의 Body를 살펴보니 `none`, `form-data`, `x-www-form-urlencoded`, `raw`, `binary`, `GraphQL`의 형식을 선택할 수 있었다. `form-data`로 Post를 보냈더니 Get 방식의 Parameter 전달 형식과 달라 파싱하지 못했다. `x-www-form-urlencoded` 방식으로 보내서 Get 방식일 때의 파싱 메소드를 재활용했다.

## 기타