### PR TITLE
[정성태] step-8 리팩토링

### DIFF
--- a/src/main/java/controller/DynamicFileController.java
+++ b/src/main/java/controller/DynamicFileController.java
@@ -12,6 +12,7 @@ import webserver.http.model.Response;
 import java.util.Collection;
 import java.util.Map;
 
+import static service.PostService.*;
 import static webserver.http.HttpUtil.*;
 import static webserver.http.HttpParser.*;
 import static webserver.http.model.Request.Method;
@@ -85,8 +86,11 @@ public class DynamicFileController extends FileController{
 
     @RequestMapping(value="/qna/form.html", method=Method.POST)
     public Response createQna(Request request) {
-        Map<String, String> bodyParameterMap = parseBodyParameter(request.getBody());
-        PostService.addPost(bodyParameterMap);
+        PostService.addPost(
+                request.getParameter(POST_WRITER),
+                request.getParameter(POST_TITLE),
+                request.getParameter(POST_CONTENT)
+        );
 
         return generate303Response(INDEX_URL);
     }

--- a/src/main/java/controller/ServiceController.java
+++ b/src/main/java/controller/ServiceController.java
@@ -11,10 +11,9 @@ import webserver.http.model.Response;
 import java.util.HashMap;
 import java.util.Map;
 
+import static model.User.*;
 import static webserver.http.HttpUtil.*;
 import static webserver.http.HttpParser.*;
-import static model.User.PASSWORD;
-import static model.User.USERID;
 
 public class ServiceController extends Controller {
 
@@ -22,7 +21,10 @@ public class ServiceController extends Controller {
     public Response userCreate(Request request) {
         Map<String, String> bodyParameterMap = parseBodyParameter(request.getBody());
 
-        UserService.userSignUp(bodyParameterMap);
+        UserService.userSignup(
+                bodyParameterMap.get(USERID), bodyParameterMap.get(PASSWORD),
+                bodyParameterMap.get(NAME), bodyParameterMap.get(EMAIL)
+        );
 
         return generate303Response(INDEX_URL);
     }

--- a/src/main/java/router/Router.java
+++ b/src/main/java/router/Router.java
@@ -52,16 +52,15 @@ public class Router {
             // 모든 로직에서 처리되지 않는 경우 404 Not Found 반환
             throw new NotFoundException();
         }
-        catch (HTTPException e) {
-            return e.generateResponse();
+        catch (HTTPException httpException) {
+            throw httpException;
         }
         catch (InvocationTargetException e) {
-            HTTPException httpException = (HTTPException) e.getTargetException();
-            return httpException.generateResponse();
+            throw (HTTPException) e.getTargetException();
         }
         catch (Exception e) {
             logger.error(Arrays.toString(e.getStackTrace()));
-            return new InternalServerErrorException().generateResponse();
+            throw new InternalServerErrorException();
         }
     }
 

--- a/src/main/java/service/PostService.java
+++ b/src/main/java/service/PostService.java
@@ -12,8 +12,8 @@ public class PostService {
     public static final String POST_TITLE = "title";
     public static final String POST_CONTENT = "contents";
 
-    public static Post addPost(Map<String, String> parameterMap) {
-        Post post = new Post(parameterMap.get(POST_WRITER), parameterMap.get(POST_TITLE), parameterMap.get(POST_CONTENT));
+    public static Post addPost(String postWriter, String postTitle, String postContent) {
+        Post post = new Post(postWriter, postTitle, postContent);
         Database.addPost(post);
         return post;
     }

--- a/src/main/java/service/UserService.java
+++ b/src/main/java/service/UserService.java
@@ -17,17 +17,14 @@ public class UserService {
         return Database.findAllUser();
     }
 
-    public static void userSignUp(Map<String, String> parameterMap) {
+    public static void userSignup(String userId, String password, String name, String email) {
         // 이미 존재하는 User인지 확인
-        User user = Database.findUserById(parameterMap.get(USERID));
+        User user = Database.findUserById(userId);
         if(user != null) {
             return;
         }
         // User 객체 생성
-        user = new User(parameterMap.get(USERID),
-                parameterMap.get(PASSWORD),
-                parameterMap.get(NAME),
-                parameterMap.get(EMAIL));
+        user = new User(userId, password, name, email);
         // DB 저장
         Database.addUser(user);
     }

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -1,5 +1,6 @@
 package webserver;
 
+import exception.HTTPException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import router.Router;
@@ -33,6 +34,14 @@ public class RequestHandler implements Runnable {
                 connection.getPort());
 
         try(connection) {
+            handleRequest(connection);
+        } catch (Exception e) {
+            logger.error(e.getMessage());
+        }
+    }
+
+    private void handleRequest(Socket connection) throws IOException {
+        try {
             // Request
             InputStream in = connection.getInputStream();
             Request request = new Request(in);
@@ -43,9 +52,10 @@ public class RequestHandler implements Runnable {
             // Send Response
             OutputStream out = connection.getOutputStream();
             response.sendResponse(out);
-
-        } catch (Exception e) {
-            logger.error(e.getMessage());
+        }
+        catch (HTTPException e) {
+            OutputStream out = connection.getOutputStream();
+            e.generateResponse().sendResponse(out);
         }
     }
 }

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -42,32 +42,10 @@ public class RequestHandler implements Runnable {
 
             // Send Response
             OutputStream out = connection.getOutputStream();
-            sendResponse(response, out);
+            response.sendResponse(out);
 
         } catch (Exception e) {
             logger.error(e.getMessage());
         }
-    }
-
-    public static void sendResponse(Response response, OutputStream out) throws IOException {
-        DataOutputStream dos = new DataOutputStream(out);
-
-        // StatusLine
-        STATUS status = response.getStatus();
-        dos.writeBytes(HEADER_HTTP + response.getVersion() + " " +
-                status.getStatusCode() + " " + status.getStatusMessage() + "\r\n");
-        // Headers
-        for (Map.Entry<String, String> entry : response.getHeaderMap().entrySet()) {
-            String key = entry.getKey();
-            String value = entry.getValue();
-            dos.writeBytes(key + ": " + value + "\r\n");
-        }
-        dos.writeBytes("\r\n");
-        // Body
-        byte[] body = response.getBody();
-        if(body != null) {
-            dos.write(body, 0, body.length);
-        }
-        dos.flush();
     }
 }

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -62,6 +62,7 @@ public class RequestHandler implements Runnable {
 
         Map<String, String> queryParameterMap = parseQueryParameter(targetUri);
 
+
         // Headers
         Map<String, String> headerMap = new HashMap<>();
         String line = readSingleHTTPLine(br).replace(" ", "");
@@ -87,8 +88,9 @@ public class RequestHandler implements Runnable {
 
             body = URLDecoder.decode(String.valueOf(bodyCharacters), StandardCharsets.UTF_8);
         }
+        Map<String, String> bodyParameterMap = parseBodyParameter(body);
 
-        return new Request(method, version, targetUri, path, queryParameterMap, headerMap, sid, body);
+        return new Request(method, version, targetUri, path, queryParameterMap, headerMap, sid, body, bodyParameterMap);
     }
 
     public static Response generateResponse(Request request) {

--- a/src/main/java/webserver/RequestHandler.java
+++ b/src/main/java/webserver/RequestHandler.java
@@ -81,14 +81,15 @@ public class RequestHandler implements Runnable {
 
         // Body
         String body = "";
+        Map<String, String> bodyParameterMap = new HashMap<>();
         if(method == Method.PUT || method == Method.POST) {
             int contentLength = Integer.parseInt(headerMap.get(HEADER_CONTENT_LENGTH));
             char[] bodyCharacters = new char[contentLength];
             br.read(bodyCharacters);
 
             body = URLDecoder.decode(String.valueOf(bodyCharacters), StandardCharsets.UTF_8);
+            bodyParameterMap = parseBodyParameter(body);
         }
-        Map<String, String> bodyParameterMap = parseBodyParameter(body);
 
         return new Request(method, version, targetUri, path, queryParameterMap, headerMap, sid, body, bodyParameterMap);
     }

--- a/src/main/java/webserver/WebServer.java
+++ b/src/main/java/webserver/WebServer.java
@@ -42,21 +42,20 @@ public class WebServer {
     }
 
     private static void testSetup() {
-        Map<String, String> parameterMap;
-        parameterMap = new HashMap<>();
-        parameterMap.put(POST_WRITER, "침착맨");
-        parameterMap.put(POST_TITLE, "추천 웹툰: 이말년 서유기");
-        parameterMap.put(POST_CONTENT, "");
-        PostService.addPost(parameterMap);
-        parameterMap = new HashMap<>();
-        parameterMap.put(POST_WRITER, "예언자");
-        parameterMap.put(POST_TITLE, "내일 MS가 블리자드를 합병할 것입니다!");
-        parameterMap.put(POST_CONTENT, "");
-        PostService.addPost(parameterMap);
-        parameterMap = new HashMap<>();
-        parameterMap.put(POST_WRITER, "호눅스");
-        parameterMap.put(POST_TITLE, "안녕하세요~ 크롱입니다.");
-        parameterMap.put(POST_CONTENT, "");
-        PostService.addPost(parameterMap);
+        PostService.addPost(
+                "침착맨",
+                "추천 웹툰: 이말년 서유기",
+                ""
+        );
+        PostService.addPost(
+                "예언자",
+                "내일 MS가 블리자드를 합병할 것입니다!",
+                ""
+        );
+        PostService.addPost(
+                "호눅스",
+                "안녕하세요~ 크롱입니다.",
+                ""
+        );
     }
 }

--- a/src/main/java/webserver/WebServer.java
+++ b/src/main/java/webserver/WebServer.java
@@ -45,17 +45,17 @@ public class WebServer {
         PostService.addPost(
                 "침착맨",
                 "추천 웹툰: 이말년 서유기",
-                ""
+                "이말년 서유기는 정말 재밌습니다!"
         );
         PostService.addPost(
                 "예언자",
                 "내일 MS가 블리자드를 합병할 것입니다!",
-                ""
+                "진짜에요!"
         );
         PostService.addPost(
                 "호눅스",
                 "안녕하세요~ 크롱입니다.",
-                ""
+                "반가워요!"
         );
     }
 }

--- a/src/main/java/webserver/http/HttpParser.java
+++ b/src/main/java/webserver/http/HttpParser.java
@@ -21,6 +21,10 @@ public class HttpParser {
             throw new InternalServerErrorException();
         }
 
+        if(line == null) {
+            return "";
+        }
+
         return URLDecoder.decode(line, StandardCharsets.UTF_8);
     }
 

--- a/src/main/java/webserver/http/HttpParser.java
+++ b/src/main/java/webserver/http/HttpParser.java
@@ -50,7 +50,7 @@ public class HttpParser {
         // ?를 기준으로 쿼리 스트링 분할
         String[] tokens = route.split("\\?");
         if(tokens.length < 2) {
-            return null;
+            return new HashMap<>();
         }
         String queryString = tokens[1];
 

--- a/src/main/java/webserver/http/model/Request.java
+++ b/src/main/java/webserver/http/model/Request.java
@@ -19,17 +19,19 @@ public class Request {
     private final Method method;
     private final String version;
     private final String targetUri;
+    private final String path;
     private final Map<String, String> queryParameterMap;
     private final Map<String, String> headerMap;
     private final String sid;
     private final String body;
 
-    public Request(Method method, String version, String targetUri,
+    public Request(Method method, String version, String targetUri, String path,
                    Map<String, String> queryParameterMap, Map<String, String> headerMap,
                    String sid, String body) {
         this.method = method;
         this.version = version;
         this.targetUri = targetUri;
+        this.path = path;
         this.queryParameterMap = queryParameterMap;
         this.headerMap = headerMap;
         this.sid = sid;
@@ -46,6 +48,10 @@ public class Request {
 
     public String getTargetUri() {
         return targetUri;
+    }
+
+    public String getPath() {
+        return path;
     }
 
     public Map<String, String> getQueryParameterMap() {

--- a/src/main/java/webserver/http/model/Request.java
+++ b/src/main/java/webserver/http/model/Request.java
@@ -24,10 +24,11 @@ public class Request {
     private final Map<String, String> headerMap;
     private final String sid;
     private final String body;
+    private final Map<String, String> bodyParameterMap;
 
     public Request(Method method, String version, String targetUri, String path,
                    Map<String, String> queryParameterMap, Map<String, String> headerMap,
-                   String sid, String body) {
+                   String sid, String body, Map<String, String> bodyParameterMap) {
         this.method = method;
         this.version = version;
         this.targetUri = targetUri;
@@ -36,6 +37,7 @@ public class Request {
         this.headerMap = headerMap;
         this.sid = sid;
         this.body = body;
+        this.bodyParameterMap = bodyParameterMap;
     }
 
     public Method getMethod() {
@@ -78,4 +80,11 @@ public class Request {
         return body;
     }
 
+    public Map<String, String> getBodyParameterMap() {
+        return bodyParameterMap;
+    }
+
+    public String getBodyParameter(String key) {
+        return bodyParameterMap.get(key);
+    }
 }

--- a/src/main/java/webserver/http/model/Request.java
+++ b/src/main/java/webserver/http/model/Request.java
@@ -1,8 +1,20 @@
 package webserver.http.model;
 
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
+
+import static service.SessionService.isSessionValid;
+import static webserver.http.HttpParser.*;
+import static webserver.http.HttpUtil.HEADER_CONTENT_LENGTH;
+import static webserver.http.HttpUtil.HEADER_COOKIE;
 
 public class Request {
     public enum Method {
@@ -16,19 +28,62 @@ public class Request {
         }
     }
 
-    private final Method method;
-    private final String version;
-    private final String targetUri;
-    private final String path;
-    private final Map<String, String> queryParameterMap;
-    private final Map<String, String> headerMap;
-    private final String sid;
-    private final String body;
-    private final Map<String, String> bodyParameterMap;
+    private Method method;
+    private String version;
+    private String targetUri;
+    private String path;
+    private Map<String, String> queryParameterMap;
+    private Map<String, String> headerMap;
+    private String sid;
+    private String body;
+    private Map<String, String> bodyParameterMap;
 
-    public Request(Method method, String version, String targetUri, String path,
-                   Map<String, String> queryParameterMap, Map<String, String> headerMap,
-                   String sid, String body, Map<String, String> bodyParameterMap) {
+    public Request(InputStream in) throws IOException {
+        parseRequest(in);
+    }
+
+    private void parseRequest(InputStream in) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(in, StandardCharsets.UTF_8));
+
+        // Status Line
+        String[] tokens = readSingleHTTPLine(br).split(" ");
+
+        Method method = Method.getMethodByName(tokens[0]);
+        String targetUri = tokens[1];
+        String path = tokens[1].split("\\?")[0];
+        String version = tokens[2].split("/")[1];
+
+        Map<String, String> queryParameterMap = parseQueryParameter(targetUri);
+
+
+        // Headers
+        Map<String, String> headerMap = new HashMap<>();
+        String line = readSingleHTTPLine(br).replace(" ", "");
+        while(!line.equals("")) {
+            tokens = line.split(":");
+            headerMap.put(tokens[0], tokens[1]);
+            line = readSingleHTTPLine(br).replace(" ", "");
+        }
+        String sid = null;
+        if(headerMap.containsKey(HEADER_COOKIE)) {
+            sid = headerMap.get(HEADER_COOKIE).split("=")[1];
+            if(!isSessionValid(sid)) {
+                sid = null;
+            }
+        }
+
+        // Body
+        String body = "";
+        Map<String, String> bodyParameterMap = new HashMap<>();
+        if(method == Method.PUT || method == Method.POST) {
+            int contentLength = Integer.parseInt(headerMap.get(HEADER_CONTENT_LENGTH));
+            char[] bodyCharacters = new char[contentLength];
+            br.read(bodyCharacters);
+
+            body = URLDecoder.decode(String.valueOf(bodyCharacters), StandardCharsets.UTF_8);
+            bodyParameterMap = parseBodyParameter(body);
+        }
+
         this.method = method;
         this.version = version;
         this.targetUri = targetUri;

--- a/src/main/java/webserver/http/model/Request.java
+++ b/src/main/java/webserver/http/model/Request.java
@@ -87,4 +87,16 @@ public class Request {
     public String getBodyParameter(String key) {
         return bodyParameterMap.get(key);
     }
+
+    // queryParamter 혹은 bodyParameter에 해당 key가 존재하면 value를 반환합니다.(그렇지 않다면 null 반환)
+    public String getParameter(String key) {
+        if(queryParameterMap.containsKey(key)) {
+            return queryParameterMap.get(key);
+        }
+        if(bodyParameterMap.containsKey(key)) {
+            return bodyParameterMap.get(key);
+        }
+
+        return null;
+    }
 }

--- a/src/main/java/webserver/http/model/Response.java
+++ b/src/main/java/webserver/http/model/Response.java
@@ -1,5 +1,8 @@
 package webserver.http.model;
 
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
 import java.util.Map;
 
 import static webserver.http.HttpUtil.*;
@@ -30,5 +33,25 @@ public class Response {
 
     public byte[] getBody() {
         return body;
+    }
+
+    public void sendResponse(OutputStream out) throws IOException {
+        DataOutputStream dos = new DataOutputStream(out);
+
+        // StatusLine
+        dos.writeBytes(HEADER_HTTP + version + " " +
+                status.getStatusCode() + " " + status.getStatusMessage() + "\r\n");
+        // Headers
+        for (Map.Entry<String, String> entry : headerMap.entrySet()) {
+            String key = entry.getKey();
+            String value = entry.getValue();
+            dos.writeBytes(key + ": " + value + "\r\n");
+        }
+        dos.writeBytes("\r\n");
+        // Body
+        if(body != null) {
+            dos.write(body, 0, body.length);
+        }
+        dos.flush();
     }
 }

--- a/src/test/java/controller/DynamicFileControllerTest.java
+++ b/src/test/java/controller/DynamicFileControllerTest.java
@@ -1,5 +1,6 @@
 package controller;
 
+import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import service.UserService;
@@ -11,6 +12,9 @@ import java.io.FileNotFoundException;
 import java.io.InputStream;
 import java.util.Map;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static webserver.http.HttpUtil.*;
+
 class DynamicFileControllerTest {
     private final String testDirectory = "./src/test/java/controller/";
     private static final DynamicFileController dynamicFileController = new DynamicFileController();
@@ -21,17 +25,17 @@ class DynamicFileControllerTest {
     }
 
     @Test
-    public void showUserList() throws Exception {
+    public void showUserListRedirect() throws Exception {
         // Given
-        UserService.userSignup("jst0951", "password", "정성태", "jst0951@gmail.com");
+        UserService.userSignup("jst0951", "q1w2e3r4", "정성태", "jst0951@gmail.com");
 
-        InputStream in = new FileInputStream(testDirectory + "Http_GET.txt");
+        InputStream in = new FileInputStream(testDirectory + "userListGet.txt");
         Request request = new Request(in);
 
         // When
         Response response = dynamicFileController.showUserList(request);
 
         // Then
-
+        assertThat(response.getStatus()).isEqualTo(STATUS.SEE_OTHER);
     }
 }

--- a/src/test/java/controller/DynamicFileControllerTest.java
+++ b/src/test/java/controller/DynamicFileControllerTest.java
@@ -1,0 +1,37 @@
+package controller;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import service.UserService;
+import webserver.http.model.Request;
+import webserver.http.model.Response;
+
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+import java.util.Map;
+
+class DynamicFileControllerTest {
+    private final String testDirectory = "./src/test/java/controller/";
+    private static final DynamicFileController dynamicFileController = new DynamicFileController();
+
+    @BeforeEach
+    public void setup() {
+        UserService.clearUserDatabase();
+    }
+
+    @Test
+    public void showUserList() throws Exception {
+        // Given
+        UserService.userSignup("jst0951", "password", "정성태", "jst0951@gmail.com");
+
+        InputStream in = new FileInputStream(testDirectory + "Http_GET.txt");
+        Request request = new Request(in);
+
+        // When
+        Response response = dynamicFileController.showUserList(request);
+
+        // Then
+
+    }
+}

--- a/src/test/java/controller/userListGET.txt
+++ b/src/test/java/controller/userListGET.txt
@@ -1,0 +1,4 @@
+GET /user/list.html HTTP/1.1
+Host: localhost:8080
+Connection: keep-alive
+Accept: */*

--- a/src/test/java/service/PostServiceTest.java
+++ b/src/test/java/service/PostServiceTest.java
@@ -23,14 +23,8 @@ class PostServiceTest {
     @Test
     @DisplayName("Post를 생성하면 DB에 저장된다.")
     public void addPost() {
-        // Given
-        Map<String, String> parameterMap = new HashMap<>();
-        parameterMap.put(POST_WRITER, "jst0951");
-        parameterMap.put(POST_TITLE, "글");
-        parameterMap.put(POST_CONTENT, "글내용");
-
-        // When
-        Post post = PostService.addPost(parameterMap);
+        // Given, When
+        Post post = PostService.addPost("jst0951", "글", "글내용");
 
         // Then
         SoftAssertions assertions = new SoftAssertions();
@@ -44,11 +38,7 @@ class PostServiceTest {
     @DisplayName("postId로 Post를 찾을 수 있어야 한다.")
     public void getPostByPostId() {
         // Given
-        Map<String, String> parameterMap = new HashMap<>();
-        parameterMap.put(POST_WRITER, "jst0951");
-        parameterMap.put(POST_TITLE, "글");
-        parameterMap.put(POST_CONTENT, "글내용");
-        Post savedPost = PostService.addPost(parameterMap);
+        Post savedPost = PostService.addPost("jst0951", "글", "글내용");
 
         // When
         Post foundPost = PostService.getPostByPostId(savedPost.getPostId());
@@ -61,21 +51,9 @@ class PostServiceTest {
     @DisplayName("특정 userId의 모든 Post를 찾을 수 있어야 한다.")
     public void getAllPostByUserId() {
         // Given
-        Map<String, String> parameterMap = new HashMap<>();
-        parameterMap.put(POST_WRITER, "jst0951");
-        parameterMap.put(POST_TITLE, "글1");
-        parameterMap.put(POST_CONTENT, "글내용1");
-        Post post1 = PostService.addPost(parameterMap);
-
-        parameterMap.put(POST_WRITER, "jst0082");
-        parameterMap.put(POST_TITLE, "글2");
-        parameterMap.put(POST_CONTENT, "글내용2");
-        Post post2 = PostService.addPost(parameterMap);
-
-        parameterMap.put(POST_WRITER, "jst0951");
-        parameterMap.put(POST_TITLE, "글3");
-        parameterMap.put(POST_CONTENT, "글내용3");
-        Post post3 = PostService.addPost(parameterMap);
+        Post post1 = PostService.addPost("jst0951", "글1", "글내용1");
+        Post post2 = PostService.addPost("jst0082", "글2", "글내용2");
+        Post post3 = PostService.addPost("jst0951", "글3", "글내용3");
 
         // When
         Collection<Post> posts = PostService.getAllPostByUserId("jst0951");
@@ -92,16 +70,8 @@ class PostServiceTest {
     @DisplayName("모든 추가된 Post를 반환해야 한다.")
     public void getAllPost() {
         // Given
-        Map<String, String> parameterMap = new HashMap<>();
-        parameterMap.put(POST_WRITER, "jst0951");
-        parameterMap.put(POST_TITLE, "글1");
-        parameterMap.put(POST_CONTENT, "글내용1");
-        Post post1 = PostService.addPost(parameterMap);
-
-        parameterMap.put(POST_WRITER, "jst0082");
-        parameterMap.put(POST_TITLE, "글2");
-        parameterMap.put(POST_CONTENT, "글내용2");
-        Post post2 = PostService.addPost(parameterMap);
+        Post post1 = PostService.addPost("jst0951", "글1", "글내용1");
+        Post post2 = PostService.addPost("jst0082", "글2", "글내용2");
 
         // When
         Collection<Post> posts = PostService.getAllPost();
@@ -118,11 +88,7 @@ class PostServiceTest {
     @DisplayName("Post 갱신 후에 최신의 값이 반환되어야 한다.")
     public void updatePost() {
         // Given
-        Map<String, String> parameterMap = new HashMap<>();
-        parameterMap.put(POST_WRITER, "jst0951");
-        parameterMap.put(POST_TITLE, "글1");
-        parameterMap.put(POST_CONTENT, "글내용1");
-        Post post = PostService.addPost(parameterMap);
+        Post post = PostService.addPost("jst0951", "글1", "글내용1");
 
         // When
         PostService.updatePost(post.getPostId(), new Post("jst0082", "글2", "글내용2"));

--- a/src/test/java/service/UserServiceTest.java
+++ b/src/test/java/service/UserServiceTest.java
@@ -8,8 +8,8 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Map;
 
+import static model.User.*;
 import static webserver.http.HttpParser.*;
-import static model.User.PASSWORD;
 
 class UserServiceTest {
     @BeforeEach
@@ -26,7 +26,10 @@ class UserServiceTest {
         Map<String, String> queryParameterMap = parseQueryParameter(targetUri);
 
         // When
-        UserService.userSignUp(queryParameterMap);
+        UserService.userSignup(
+                queryParameterMap.get(USERID), queryParameterMap.get(PASSWORD),
+                queryParameterMap.get(NAME), queryParameterMap.get(EMAIL)
+        );
 
         // Then
         SoftAssertions assertions = new SoftAssertions();
@@ -41,11 +44,17 @@ class UserServiceTest {
         // Given
         String targetUri = "/user/create?userId=jst0951&password=password&name=정성태&email=jst0951@naver.com";
         Map<String, String> queryParameterMap = parseQueryParameter(targetUri);
-        UserService.userSignUp(queryParameterMap);
+        UserService.userSignup(
+                queryParameterMap.get(USERID), queryParameterMap.get(PASSWORD),
+                queryParameterMap.get(NAME), queryParameterMap.get(EMAIL)
+        );
 
         // When
         queryParameterMap.put(PASSWORD, "newPassword");
-        UserService.userSignUp(queryParameterMap);
+        UserService.userSignup(
+                queryParameterMap.get(USERID), queryParameterMap.get(PASSWORD),
+                queryParameterMap.get(NAME), queryParameterMap.get(EMAIL)
+        );
 
         // Then
         SoftAssertions assertions = new SoftAssertions();

--- a/src/test/resources/HTTP_Cookie.txt
+++ b/src/test/resources/HTTP_Cookie.txt
@@ -1,0 +1,4 @@
+HTTP/1.1 303 See Other
+Set-Cookie: sid=1234; Path=/
+Location: /index.html
+

--- a/src/test/resources/HTTP_Forward.txt
+++ b/src/test/resources/HTTP_Forward.txt
@@ -1,0 +1,3 @@
+HTTP/1.1 303 See Other
+Location: /index.html
+

--- a/src/test/resources/HTTP_Redirect.txt
+++ b/src/test/resources/HTTP_Redirect.txt
@@ -1,0 +1,3 @@
+HTTP/1.1 303 See Other
+Location: /user/login.html
+

--- a/src/test/resources/HttpRequestTest.java
+++ b/src/test/resources/HttpRequestTest.java
@@ -22,9 +22,13 @@ public class HttpRequestTest {
 
     @Test
     public void request_GET() throws Exception {
+        // Given
         InputStream in = new FileInputStream(testDirectory + "Http_GET.txt");
+
+        // When
         Request request = new Request(in);
 
+        // Then
         SoftAssertions assertions = new SoftAssertions();
         assertions.assertThat(request.getMethod()).isEqualTo(Method.GET);
         assertions.assertThat(request.getPath()).isEqualTo("/user/create");
@@ -35,9 +39,13 @@ public class HttpRequestTest {
 
     @Test
     public void request_POST() throws Exception {
+        // Given
         InputStream in = new FileInputStream(testDirectory + "Http_POST.txt");
+
+        // When
         Request request = new Request(in);
 
+        // Then
         SoftAssertions assertions = new SoftAssertions();
         assertions.assertThat(request.getMethod()).isEqualTo(Method.POST);
         assertions.assertThat(request.getPath()).isEqualTo("/user/create");
@@ -48,9 +56,13 @@ public class HttpRequestTest {
 
     @Test
     public void request_POST2() throws Exception {
+        // Given
         InputStream in = new FileInputStream(testDirectory + "Http_POST2.txt");
+
+        // When
         Request request = new Request(in);
 
+        // Then
         SoftAssertions assertions = new SoftAssertions();
         assertions.assertThat(request.getMethod()).isEqualTo(Method.POST);
         assertions.assertThat(request.getPath()).isEqualTo("/user/create");

--- a/src/test/resources/HttpRequestTest.java
+++ b/src/test/resources/HttpRequestTest.java
@@ -1,0 +1,27 @@
+package resources;
+
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.Test;
+import webserver.http.model.Request;
+
+import java.io.FileInputStream;
+import java.io.InputStream;
+
+import static webserver.RequestHandler.parseRequest;
+
+public class HttpRequestTest {
+    private String testDirectory = "./src/test/resources/";
+
+    @Test
+    public void request_GET() throws Exception {
+        InputStream in = new FileInputStream(testDirectory + "Http_GET.txt");
+        Request request = parseRequest(in);
+
+        SoftAssertions assertions = new SoftAssertions();
+        assertions.assertThat(request.getMethod()).isEqualTo(Request.Method.GET);
+        assertions.assertThat(request.getPath()).isEqualTo("/user/create");
+        assertions.assertThat(request.getHeader("Connection")).isEqualTo("keep-alive");
+        assertions.assertThat(request.getQueryParameter("userId")).isEqualTo("javajigi");
+        assertions.assertAll();
+    }
+}

--- a/src/test/resources/HttpRequestTest.java
+++ b/src/test/resources/HttpRequestTest.java
@@ -36,8 +36,7 @@ public class HttpRequestTest {
         assertions.assertThat(request.getMethod()).isEqualTo(Method.POST);
         assertions.assertThat(request.getPath()).isEqualTo("/user/create");
         assertions.assertThat(request.getHeader("Connection")).isEqualTo("keep-alive");
-        Map<String, String> parameterMap = parseBodyParameter(request.getBody());
-        assertions.assertThat(parameterMap.get("userId")).isEqualTo("javajigi");
+        assertions.assertThat(request.getBodyParameter("userId")).isEqualTo("javajigi");
         assertions.assertAll();
     }
 }

--- a/src/test/resources/HttpRequestTest.java
+++ b/src/test/resources/HttpRequestTest.java
@@ -39,4 +39,18 @@ public class HttpRequestTest {
         assertions.assertThat(request.getBodyParameter("userId")).isEqualTo("javajigi");
         assertions.assertAll();
     }
+
+    @Test
+    public void request_POST2() throws Exception {
+        InputStream in = new FileInputStream(testDirectory + "Http_POST2.txt");
+        Request request = parseRequest(in);
+
+        SoftAssertions assertions = new SoftAssertions();
+        assertions.assertThat(request.getMethod()).isEqualTo(Method.POST);
+        assertions.assertThat(request.getPath()).isEqualTo("/user/create");
+        assertions.assertThat(request.getHeader("Connection")).isEqualTo("keep-alive");
+        assertions.assertThat(request.getQueryParameter("id")).isEqualTo("1");
+        assertions.assertThat(request.getBodyParameter("userId")).isEqualTo("javajigi");
+        assertions.assertAll();
+    }
 }

--- a/src/test/resources/HttpRequestTest.java
+++ b/src/test/resources/HttpRequestTest.java
@@ -2,11 +2,20 @@ package resources;
 
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.Test;
+import router.Router;
+import webserver.http.HttpUtil;
 import webserver.http.model.Request;
 import webserver.http.model.Request.Method;
+import webserver.http.model.Response;
 
-import java.io.FileInputStream;
-import java.io.InputStream;
+import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static webserver.http.HttpUtil.HEADER_REDIRECT_LOCATION;
 
 public class HttpRequestTest {
     private String testDirectory = "./src/test/resources/";
@@ -23,6 +32,7 @@ public class HttpRequestTest {
         assertions.assertThat(request.getParameter("userId")).isEqualTo("javajigi");
         assertions.assertAll();
     }
+
     @Test
     public void request_POST() throws Exception {
         InputStream in = new FileInputStream(testDirectory + "Http_POST.txt");
@@ -48,5 +58,24 @@ public class HttpRequestTest {
         assertions.assertThat(request.getParameter("id")).isEqualTo("1");
         assertions.assertThat(request.getParameter("userId")).isEqualTo("javajigi");
         assertions.assertAll();
+    }
+
+    @Test
+    public void responseForward() throws Exception {
+        // Given
+        Map<String, String> headerMap = new HashMap<>();
+        headerMap.put(HEADER_REDIRECT_LOCATION, "/index.html");
+        Response response = new Response(HttpUtil.STATUS.SEE_OTHER, headerMap, null);
+
+        // When
+        response.sendResponse(createOutputStream("HTTP_Forward.txt"));
+
+        // Then
+        String body = new String(Files.readAllBytes(Paths.get(testDirectory + "HTTP_Forward.txt")));
+        assertThat(body).contains("/index.html");
+    }
+
+    private OutputStream createOutputStream(String filename) throws FileNotFoundException {
+        return new FileOutputStream(testDirectory + filename);
     }
 }

--- a/src/test/resources/HttpRequestTest.java
+++ b/src/test/resources/HttpRequestTest.java
@@ -3,11 +3,14 @@ package resources;
 import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.Test;
 import webserver.http.model.Request;
+import webserver.http.model.Request.Method;
 
 import java.io.FileInputStream;
 import java.io.InputStream;
+import java.util.Map;
 
 import static webserver.RequestHandler.parseRequest;
+import static webserver.http.HttpParser.parseBodyParameter;
 
 public class HttpRequestTest {
     private String testDirectory = "./src/test/resources/";
@@ -18,10 +21,23 @@ public class HttpRequestTest {
         Request request = parseRequest(in);
 
         SoftAssertions assertions = new SoftAssertions();
-        assertions.assertThat(request.getMethod()).isEqualTo(Request.Method.GET);
+        assertions.assertThat(request.getMethod()).isEqualTo(Method.GET);
         assertions.assertThat(request.getPath()).isEqualTo("/user/create");
         assertions.assertThat(request.getHeader("Connection")).isEqualTo("keep-alive");
         assertions.assertThat(request.getQueryParameter("userId")).isEqualTo("javajigi");
+        assertions.assertAll();
+    }
+    @Test
+    public void request_POST() throws Exception {
+        InputStream in = new FileInputStream(testDirectory + "Http_POST.txt");
+        Request request = parseRequest(in);
+
+        SoftAssertions assertions = new SoftAssertions();
+        assertions.assertThat(request.getMethod()).isEqualTo(Method.POST);
+        assertions.assertThat(request.getPath()).isEqualTo("/user/create");
+        assertions.assertThat(request.getHeader("Connection")).isEqualTo("keep-alive");
+        Map<String, String> parameterMap = parseBodyParameter(request.getBody());
+        assertions.assertThat(parameterMap.get("userId")).isEqualTo("javajigi");
         assertions.assertAll();
     }
 }

--- a/src/test/resources/HttpRequestTest.java
+++ b/src/test/resources/HttpRequestTest.java
@@ -7,10 +7,8 @@ import webserver.http.model.Request.Method;
 
 import java.io.FileInputStream;
 import java.io.InputStream;
-import java.util.Map;
 
 import static webserver.RequestHandler.parseRequest;
-import static webserver.http.HttpParser.parseBodyParameter;
 
 public class HttpRequestTest {
     private String testDirectory = "./src/test/resources/";
@@ -24,7 +22,7 @@ public class HttpRequestTest {
         assertions.assertThat(request.getMethod()).isEqualTo(Method.GET);
         assertions.assertThat(request.getPath()).isEqualTo("/user/create");
         assertions.assertThat(request.getHeader("Connection")).isEqualTo("keep-alive");
-        assertions.assertThat(request.getQueryParameter("userId")).isEqualTo("javajigi");
+        assertions.assertThat(request.getParameter("userId")).isEqualTo("javajigi");
         assertions.assertAll();
     }
     @Test
@@ -36,7 +34,7 @@ public class HttpRequestTest {
         assertions.assertThat(request.getMethod()).isEqualTo(Method.POST);
         assertions.assertThat(request.getPath()).isEqualTo("/user/create");
         assertions.assertThat(request.getHeader("Connection")).isEqualTo("keep-alive");
-        assertions.assertThat(request.getBodyParameter("userId")).isEqualTo("javajigi");
+        assertions.assertThat(request.getParameter("userId")).isEqualTo("javajigi");
         assertions.assertAll();
     }
 
@@ -49,8 +47,8 @@ public class HttpRequestTest {
         assertions.assertThat(request.getMethod()).isEqualTo(Method.POST);
         assertions.assertThat(request.getPath()).isEqualTo("/user/create");
         assertions.assertThat(request.getHeader("Connection")).isEqualTo("keep-alive");
-        assertions.assertThat(request.getQueryParameter("id")).isEqualTo("1");
-        assertions.assertThat(request.getBodyParameter("userId")).isEqualTo("javajigi");
+        assertions.assertThat(request.getParameter("id")).isEqualTo("1");
+        assertions.assertThat(request.getParameter("userId")).isEqualTo("javajigi");
         assertions.assertAll();
     }
 }

--- a/src/test/resources/HttpRequestTest.java
+++ b/src/test/resources/HttpRequestTest.java
@@ -8,15 +8,13 @@ import webserver.http.model.Request.Method;
 import java.io.FileInputStream;
 import java.io.InputStream;
 
-import static webserver.RequestHandler.parseRequest;
-
 public class HttpRequestTest {
     private String testDirectory = "./src/test/resources/";
 
     @Test
     public void request_GET() throws Exception {
         InputStream in = new FileInputStream(testDirectory + "Http_GET.txt");
-        Request request = parseRequest(in);
+        Request request = new Request(in);
 
         SoftAssertions assertions = new SoftAssertions();
         assertions.assertThat(request.getMethod()).isEqualTo(Method.GET);
@@ -28,7 +26,7 @@ public class HttpRequestTest {
     @Test
     public void request_POST() throws Exception {
         InputStream in = new FileInputStream(testDirectory + "Http_POST.txt");
-        Request request = parseRequest(in);
+        Request request = new Request(in);
 
         SoftAssertions assertions = new SoftAssertions();
         assertions.assertThat(request.getMethod()).isEqualTo(Method.POST);
@@ -41,7 +39,7 @@ public class HttpRequestTest {
     @Test
     public void request_POST2() throws Exception {
         InputStream in = new FileInputStream(testDirectory + "Http_POST2.txt");
-        Request request = parseRequest(in);
+        Request request = new Request(in);
 
         SoftAssertions assertions = new SoftAssertions();
         assertions.assertThat(request.getMethod()).isEqualTo(Method.POST);

--- a/src/test/resources/HttpRequestTest.java
+++ b/src/test/resources/HttpRequestTest.java
@@ -15,7 +15,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static webserver.http.HttpUtil.HEADER_REDIRECT_LOCATION;
+import static webserver.http.HttpUtil.*;
 
 public class HttpRequestTest {
     private String testDirectory = "./src/test/resources/";
@@ -77,7 +77,7 @@ public class HttpRequestTest {
         // Given
         Map<String, String> headerMap = new HashMap<>();
         headerMap.put(HEADER_REDIRECT_LOCATION, "/index.html");
-        Response response = new Response(HttpUtil.STATUS.SEE_OTHER, headerMap, null);
+        Response response = new Response(STATUS.SEE_OTHER, headerMap, null);
 
         // When
         response.sendResponse(createOutputStream("HTTP_Forward.txt"));
@@ -85,6 +85,37 @@ public class HttpRequestTest {
         // Then
         String body = new String(Files.readAllBytes(Paths.get(testDirectory + "HTTP_Forward.txt")));
         assertThat(body).contains("/index.html");
+    }
+
+    @Test
+    public void responseRedirect() throws Exception {
+        // Given
+        Map<String, String> headerMap = new HashMap<>();
+        headerMap.put(HEADER_REDIRECT_LOCATION, "/user/login.html");
+        Response response = new Response(STATUS.SEE_OTHER, headerMap, null);
+
+        // When
+        response.sendResponse(createOutputStream("HTTP_Redirect.txt"));
+
+        // Then
+        String body = new String(Files.readAllBytes(Paths.get(testDirectory + "HTTP_Redirect.txt")));
+        assertThat(body).contains("/user/login.html");
+    }
+
+    @Test
+    public void responseCookies() throws Exception {
+        // Given
+        Map<String, String> headerMap = new HashMap<>();
+        headerMap.put(HEADER_REDIRECT_LOCATION, INDEX_URL);
+        headerMap.put(HEADER_SET_COOKIE, HEADER_SESSION_ID + "1234" + HEADER_COOKIE_PATH);
+        Response response = new Response(STATUS.SEE_OTHER, headerMap, null);
+
+        // When
+        response.sendResponse(createOutputStream("HTTP_Cookie.txt"));
+
+        // Then
+        String body = new String(Files.readAllBytes(Paths.get(testDirectory + "HTTP_Cookie.txt")));
+        assertThat(body).contains(HEADER_SESSION_ID + "1234" + HEADER_COOKIE_PATH);
     }
 
     private OutputStream createOutputStream(String filename) throws FileNotFoundException {

--- a/src/test/resources/Http_GET.txt
+++ b/src/test/resources/Http_GET.txt
@@ -1,0 +1,4 @@
+GET /user/create?userId=javajigi&password=password&name=JaeSung HTTP/1.1
+Host: localhost:8080
+Connection: keep-alive
+Accept: */*

--- a/src/test/resources/Http_POST.txt
+++ b/src/test/resources/Http_POST.txt
@@ -1,0 +1,8 @@
+POST /user/create HTTP/1.1
+Host: localhost:8080
+Connection: keep-alive
+Content-Length: 46
+Content-Type: application/x-www-form-urlencoded
+Accept: */*
+
+userId=javajigi&password=password&name=JaeSung

--- a/src/test/resources/Http_POST2.txt
+++ b/src/test/resources/Http_POST2.txt
@@ -1,0 +1,8 @@
+POST /user/create?id=1 HTTP/1.1
+Host: localhost:8080
+Connection: keep-alive
+Content-Length: 46
+Content-Type: application/x-www-form-urlencoded
+Accept: */*
+
+userId=javajigi&password=password&name=JaeSung


### PR DESCRIPTION
## 구현 
- [x] GET/POST 텍스트파일 기반 테스트 생성 및 확인
- [x] 파싱, 전송 책임 request, response 각 클래스에 위임
- [x] 테스트 bdd 기반으로 수정
- [x] 서비스 메서드들이 hashmap이 아닌 각 필드들을 받도록 수정
- [x] 파라미터 공통(쿼리스트링, http body) 파싱 가능한 getParamter 메서드 추가

## 고민 사항
기존 구조를 최대한 활용하며 리팩토링하려 하니, 구현 기반이 달라 어려운 부분들이 약간 존재했다. 사용자 입장에서 크게 문제되지 않을 것이라 판단되는 부분들은 제외하고 가능한 제공된대로 리팩토링을 진행하였다.

## 기타

제시된 내용과 달리 진행되지 못 한 부분이 두 부분 있다.
1. httpresponse의 공통 로직 메서드화는 기존 구조()
2. 다형성 기반으로 클라이언트 url 요청을 처리하는 로직은 기존에 어노테이션 기반으로 처리하여 수정이 어려워 진행하지 못했다.
